### PR TITLE
Legg til dekoratøren som app i outbound rules

### DIFF
--- a/.nais/naiserator.yml
+++ b/.nais/naiserator.yml
@@ -14,9 +14,12 @@ spec:
   port: 3000
   accessPolicy:
     outbound:
+      rules:
+      - application: nav-dekoratoren
+        namespace: personbruker
       external:
         - host: www.nav.no
-        - host: dekoratoren.dev.nav.no
+        
   liveness:
     path: "/api/internal/isalive"
     initialDelay: 15


### PR DESCRIPTION
Dekoratøren kræsjer fordi den ikke får prate med serveren sin. Dette fikser det forhåpentligvis.