### PR TITLE
Legg til tracking av et par forskjellige events

### DIFF
--- a/app/hooks/useDebounceCallback.ts
+++ b/app/hooks/useDebounceCallback.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * En hook som returnerer en debounced versjon av callback-funksjonen.
+ * Den debouncede funksjonen vil kun bli kalt etter at det spesifiserte delayet har gått
+ * siden den sist ble kalt.
+ *
+ * @param callback Funksjonen som skal debounce
+ * @param delay Tiden i millisekunder før funksjonen kalles
+ * @returns En debounced versjon av callback funksjonen
+ */
+export function useDebounceCallback<T extends (...args: any[]) => any>(
+  callback: T,
+  delay: number
+): (...args: Parameters<T>) => void {
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  return useCallback(
+    (...args: Parameters<T>) => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+
+      timerRef.current = setTimeout(() => {
+        callback(...args);
+      }, delay);
+    },
+    [callback, delay]
+  );
+}

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -1,0 +1,29 @@
+import { getAmplitudeInstance } from "@navikt/nav-dekoratoren-moduler";
+
+const logger = getAmplitudeInstance("barnebidragskalkulator");
+
+type EventType =
+  | "skjema validering feilet"
+  | "skjema innsending feilet"
+  | "skjema fullført"
+  | "samværsgrad justert";
+
+/**
+ * Sporer en hendelse
+ *
+ * Under utvikling logges det til console istedenfor.
+ *
+ * ```tsx
+ * await sporHendelse("skjema validering feilet", { feil: error.message })
+ * ```
+ *
+ * @param event En hendelse som skal spores
+ * @param data Optional data du kan sende med
+ * @returns Promise<void>
+ */
+export function sporHendelse(event: EventType, data?: Record<string, unknown>) {
+  if (process.env.NODE_ENV === "development") {
+    console.info(`[DEV] hendelse sporet: ${event}`, data);
+  }
+  return logger(event, data);
+}

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -2,5 +2,5 @@ import type { Config } from "@react-router/dev/config";
 
 export default {
   ssr: true,
-  basename: "/barnebidragskalkulator",
+  basename: "/barnebidragskalkulator/",
 } satisfies Config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,6 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  base: "/barnebidragskalkulator",
+  base: "/barnebidragskalkulator/",
   plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
 });


### PR DESCRIPTION
Denne PRen setter opp Navs analytics-logger, og legger til litt basic tracking.

Tingene vi sporer er:
- Når skjemavalideringen feilet (og hvilket felt som feilet, men ikke alle, og ikke hva det stod eller hva feilen var)
- Når skjemainnsendingen feilet – enten på grunn av serverfeil eller valideringsfeil i action-funksjonen (skal ikke skje, siden vi bruker samme valideringen begge steder)
- Når skjemaet blir sendt inn suksessfullt
- 5 sekunder etter at samværsgraden blir justert.