### PR TITLE
Legg ved headers i responsen

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -12,6 +12,7 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
+  type HeadersArgs,
   type LoaderFunctionArgs,
 } from "react-router";
 
@@ -73,7 +74,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         })),
       },
     }),
-    buildCspHeader({}, { env: env.ENVIRONMENT }),
+    buildCspHeader(
+      { "script-src-elem": ["'self'"], "connect-src": ["'self'"] },
+      { env: env.ENVIRONMENT }
+    ),
   ]);
 
   return data(
@@ -105,6 +109,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   );
 }
+
+export const headers = ({ loaderHeaders }: HeadersArgs) => {
+  return loaderHeaders;
+};
 
 export default function App() {
   return <Outlet />;


### PR DESCRIPTION
Denne PRen fikser to issues med headers:

1. De ble ikke sendt med HTML-responsen, kun med .data responsen. Det gjør at vi feiler securityheaders.com testen.
2. Vi tillot ikke at vi kan laste data fra vårt eget domene, som gjorde at hot reloading og slikt ikke fungerte som forventet.