### PR TITLE
Legg til X-Content-Type-Options: nosniff

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -96,6 +96,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         "Cross-Origin-Embedder-Policy": "credentialless",
         "Cross-Origin-Resource-Policy": "same-origin",
         "X-Permitted-Cross-Domain-Policies": "none",
+        "X-Content-Type-Options": "nosniff",
 
         // Andre headers
         "Cache-Control": "max-age=60, stale-while-revalidate=86400",


### PR DESCRIPTION
Denne PRen legger til en anbefalt header for å stoppe user agents (browseren) til å "mime-sniffe" innholdstypen. Det er nok ikke et reellt problem for oss, men det gir oss en bump i ratingen på securityheaders.com.

Du kan lese mer om denne headeren og hva det kan føre til [her](https://scotthelme.co.uk/hardening-your-http-response-headers/#x-content-type-options).