### PR TITLE
Adresser lighthouse findings

### DIFF
--- a/app/components/ui/slider.tsx
+++ b/app/components/ui/slider.tsx
@@ -32,6 +32,7 @@ function Slider({
 }: SliderProps) {
   const generertId = useId();
   const id = eksternId ?? generertId;
+  const labelId = `${id}-label`;
   const verdi = value
     ? [Number(value)]
     : defaultValue
@@ -44,7 +45,9 @@ function Slider({
 
   return (
     <div className="flex flex-col gap-2">
-      <Label htmlFor={id}>{label}</Label>
+      <Label htmlFor={id} id={labelId}>
+        {label}
+      </Label>
       {description && (
         <BodyShort size="small" textColor="subtle">
           {description}
@@ -63,7 +66,6 @@ function Slider({
         onValueChange={handleChange}
         {...props}
         id={id}
-        aria-labelledby={id}
       >
         <SliderPrimitive.Track
           data-slot="slider-track"
@@ -77,6 +79,7 @@ function Slider({
           />
         </SliderPrimitive.Track>
         <SliderPrimitive.Thumb
+          aria-labelledby={labelId}
           data-slot="slider-thumb"
           className="border-primary bg-blue-500 ring-ring/50 block size-5 shrink-0 rounded-full border-none shadow-sm transition-[color,box-shadow] hover:ring-4 hover:ring-blue-500 focus-visible:ring-4 focus-visible:ring-blue-500 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />

--- a/app/components/ui/slider.tsx
+++ b/app/components/ui/slider.tsx
@@ -63,6 +63,7 @@ function Slider({
         onValueChange={handleChange}
         {...props}
         id={id}
+        aria-labelledby={id}
       >
         <SliderPrimitive.Track
           data-slot="slider-track"

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -3,4 +3,5 @@ export default [
   index("routes/index.tsx"),
   route("/api/internal/isalive", "routes/api/internal/isalive.ts"),
   route("/api/internal/isready", "routes/api/internal/isready.ts"),
+  route("/.well-known/security.txt", "routes/.well-known/security.txt"),
 ] satisfies RouteConfig;

--- a/app/routes/.well-known/security.txt.ts
+++ b/app/routes/.well-known/security.txt.ts
@@ -1,0 +1,8 @@
+import { redirect } from "react-router";
+
+/** Vi har ikke vår egen security.txt, så vi henviser til Nav sin */
+export function loader() {
+  return redirect("https://www.nav.no/.well-known/security.txt", {
+    status: 301,
+  });
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+# Midlertidig blokker all indeksering
+User-agent: *
+Disallow: /
+
+# Dette forhindrer alle søkemotorer fra å indeksere nettstedet
+# Fjern eller modifiser når nettstedet er klart for offentlig indeksering


### PR DESCRIPTION
Denne PRen adresserer et par ting som dukket opp under lighthouse testing:

- Slideren hadde ingen aria-labelledby, så la på at thumb-elementet har en aria-labelledby som lenker tilbake til labelen.
- La til en redirect for .well-known/security.txt som sender deg til Nav sin generelle.
- La til en robots.txt fil som hindrer indeksering (enn så lenge i alle fall)
