### PR TITLE
Endre prod-url til å ikke inkludere beta

### DIFF
--- a/.nais/prod.json
+++ b/.nais/prod.json
@@ -2,5 +2,5 @@
   "SERVER_URL": "http://bidrag-bidragskalkulator-api",
   "ENVIRONMENT": "prod",
   "UMAMI_WEBSITE_ID": "",
-  "ingress": "https://barnebidragskalkulator-beta.nav.no"
+  "ingress": "https://barnebidragskalkulator.nav.no"
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Man deployer automatisk til dev- og prod-miljøene når man merger en pull reque
 
 **Dev-miljøet finner du på https://bidragskalkulator-v2.ekstern.dev.nav.no**
 
-**Prod-miljøet finner du på https://barnebidragskalkulator-beta.nav.no**
+**Prod-miljøet finner du på https://barnebidragskalkulator.nav.no**
 
 ## Lokal utvikling
 


### PR DESCRIPTION
Nå som @tatjanaand har slettet den gamle v2-versjonen av barnebidragskalkulatoren, kan vi bruke det riktige domenet