### PR TITLE
Fiks fokus-rekkefølgen i barneskjemaet når du legger til eller fjerner barn

### DIFF
--- a/app/features/form/BarnForm.tsx
+++ b/app/features/form/BarnForm.tsx
@@ -25,7 +25,7 @@ export function BarnForm({ item, index, canRemove, onRemove }: BarnFormProps) {
     samværsgrad === 1 ? t(tekster.enNatt) : t(tekster.netter(samværsgrad));
 
   return (
-    <div className="border p-4 rounded-md space-y-4">
+    <div className="border p-4 rounded-md space-y-4 focus:outline-none focus-visible:outline-1">
       {canRemove && (
         <Heading size="small" level="2">
           {t(tekster.barn)} {index + 1}

--- a/app/features/form/BidragsForm.tsx
+++ b/app/features/form/BidragsForm.tsx
@@ -47,7 +47,17 @@ export function BidragsForm() {
           item={item}
           index={index}
           canRemove={barnFields.length() > 1}
-          onRemove={() => barnFields.remove(index)}
+          onRemove={() => {
+            barnFields.remove(index);
+            setTimeout(() => {
+              // Dette er den gamle lengden – den blir ikke oppdatert av en eller annen grunn
+              const antallBarnFørSletting = barnFields.length();
+              if (antallBarnFørSletting > 1) {
+                const sisteIndex = antallBarnFørSletting - 2;
+                finnFokuserbartInputPåBarn(sisteIndex)?.focus();
+              }
+            }, 0);
+          }}
         />
       ))}
 
@@ -55,7 +65,14 @@ export function BidragsForm() {
         type="button"
         variant="secondary"
         size="small"
-        onClick={() => barnFields.push({ alder: "", samværsgrad: "15" })}
+        onClick={() => {
+          barnFields.push({ alder: "", samværsgrad: "15" });
+
+          setTimeout(() => {
+            const nyttBarnIndex = barnFields.length();
+            finnFokuserbartInputPåBarn(nyttBarnIndex)?.focus();
+          }, 0);
+        }}
       >
         {t(tekster.leggTilBarn)}
       </Button>
@@ -104,3 +121,12 @@ const tekster = definerTekster({
     nn: "Beregn fostringstilskotet",
   },
 });
+
+// Dette er en hjelpefunksjon for å finne det første fokuserbare input-elementet på et barn
+// Man burde egentlig brukt refs til det, men jeg klarer ikke å forstå hvordan man skal få det til med
+// react-validated-form
+const finnFokuserbartInputPåBarn = (index: number) => {
+  return document.querySelector(
+    `input[name="barn[${index}].alder"]`
+  ) as HTMLInputElement;
+};

--- a/app/features/form/FormattertTallTextField.tsx
+++ b/app/features/form/FormattertTallTextField.tsx
@@ -1,14 +1,15 @@
 import { TextField, type TextFieldProps } from "@navikt/ds-react";
-import { type ChangeEvent } from "react";
+import { type ChangeEvent, type Ref, type RefObject } from "react";
 
 export type FormattertTallTextFieldProps = Omit<TextFieldProps, "onChange"> & {
   onChange: (value: string) => void;
+  ref?: Ref<HTMLInputElement | null>;
 };
 
 /**
  * FormattertTallTextField er en komponent som formaterer et tall med tusenvis
- * og komma som desimaltegn. onChange-callbacken blir kalt med den uformatterte verdien. 
- * 
+ * og komma som desimaltegn. onChange-callbacken blir kalt med den uformatterte verdien.
+ *
  * Ellers fungerer det som et vanlig TextField.
  *
  * ```tsx


### PR DESCRIPTION
Denne PRen rydder opp i fokusrekkefølgen når man legger til eller fjerner et barn.

- Når man trykker på "legg til barn", fokuseres første inputfelt (alder) på det nye barnet som ble lagt til
- Når man trykker på slett barn, fokuseres det første inputfeltet (alder) på det siste barnet som er i listen

Jeg prøvde å gjøre det på en rekke forskjellige måter, men til slutt kom jeg frem til at å bruke `document.querySelector` var det som faktisk fungerte. Litt leit – om det er noen RVF-eksperter her, så hadde det vært flott å høre om det finnes andre måter å gjøre det på.

![2025-03-18 14 16 50](https://github.com/user-attachments/assets/84f261e5-3cd9-42f0-bdc8-d66da6bedda2)
