### PR TITLE
Legg utregningsdetaljer i et accordion, og gjør utregning bredere

### DIFF
--- a/app/features/form/ResultDisplay.tsx
+++ b/app/features/form/ResultDisplay.tsx
@@ -66,7 +66,6 @@ export const ResultDisplay = ({ data, ref }: ResultDisplayProps) => {
             {t(tekster.søkNavOmFastsetting)}
           </Button>
         </div>
-        <BodyLong spacing>{t(tekster.omtrentligSum)}</BodyLong>
         <BodyLong spacing>{t(tekster.callToActionGammelKalkulator)}</BodyLong>
         <ExpansionCard aria-labelledby="detaljer" size="small">
           <ExpansionCardHeader>
@@ -158,37 +157,37 @@ const tekster = definerTekster({
       nn: "Dette er summen som skal delast mellom deg og den andre forelderen. Kvifor det splittast, avheng av inntekt og samvær, i tillegg til ein rekkje andre forhold.",
     },
   },
-  omtrentligSum: {
-    nb: "Forslaget er basert på noen få opplysninger, som gjør det enkelt å få en omtrentlig sum.",
-    en: "The proposal is based on a few pieces of information, making it easy to get an approximate sum.",
-    nn: "Forslaget er basert på nokon få opplysningar, som gjør det enkelt å få ein omtrentleg sum.",
-  },
   callToActionGammelKalkulator: {
     nb: (
       <>
-        Om du ønsker en mer presis kalkulering, kan du bruke{" "}
+        Forslaget er basert på noen få opplysninger, som gjør det enkelt å få en
+        omtrentlig sum. Om du ønsker en mer presis kalkulering, kan du bruke{" "}
         <Link href="https://tjenester.nav.no/bidragskalkulator/innledning?0">
           den gamle bidragskalkulatoren
         </Link>{" "}
         til å legge inn flere opplysninger og få en riktigere sum.
       </>
     ),
-    nn: (
-      <>
-        Om du ynskjer ein meir presis kalkulering, kan du bruke{" "}
-        <Link href="https://tjenester.nav.no/bidragskalkulator/innledning?0">
-          den gamle bidragskalkulatoren
-        </Link>{" "}
-        til å leggje inn fleire opplysningar og få ein riktigare sum.
-      </>
-    ),
     en: (
       <>
-        If you want a more precise calculation, you can use the{" "}
+        The proposal is based on a few pieces of information, making it easy to
+        get an approximate sum. If you want a more precise calculation, you can
+        use the{" "}
         <Link href="https://tjenester.nav.no/bidragskalkulator/innledning?0">
           old child support calculator
         </Link>{" "}
         to enter more information and get a more accurate sum.
+      </>
+    ),
+    nn: (
+      <>
+        Forslaget er basert på nokon få opplysningar, som gjør det enkelt å få
+        ein omtrentleg sum. Om du ynskjer ein meir presis kalkulering, kan du
+        bruke{" "}
+        <Link href="https://tjenester.nav.no/bidragskalkulator/innledning?0">
+          den gamle bidragskalkulatoren
+        </Link>{" "}
+        til å leggje inn fleire opplysningar og få ein riktigare sum.
       </>
     ),
   },

--- a/app/features/form/ResultDisplay.tsx
+++ b/app/features/form/ResultDisplay.tsx
@@ -1,4 +1,17 @@
-import { Alert, BodyLong, Button, Heading, Link, List } from "@navikt/ds-react";
+import {
+  Alert,
+  BodyLong,
+  Button,
+  ExpansionCard,
+  Heading,
+  Link,
+  List,
+} from "@navikt/ds-react";
+import {
+  ExpansionCardContent,
+  ExpansionCardHeader,
+  ExpansionCardTitle,
+} from "@navikt/ds-react/ExpansionCard";
 import { ListItem } from "@navikt/ds-react/List";
 import { definerTekster, useOversettelse } from "~/utils/i18n";
 import { formatterSum } from "~/utils/tall";
@@ -30,30 +43,14 @@ export const ResultDisplay = ({ data, ref }: ResultDisplayProps) => {
   const totalSum = data.resultater.reduce((sum, neste) => sum + neste.sum, 0);
 
   return (
-    <div className="mt-6" ref={ref}>
+    <div ref={ref}>
       <Alert variant="info">
         <Heading size="small" spacing>
           {t(tekster.overskrift(totalSum))}
         </Heading>
         {totalSum === 0 && <BodyLong spacing>{t(tekster.nullBidrag)}</BodyLong>}
-        <BodyLong spacing>{t(tekster.innhold1)}</BodyLong>
-        <BodyLong spacing>{t(tekster.innhold2)}</BodyLong>
-        <List>
-          {data.resultater.map((resultat, index) => (
-            <ListItem key={index}>
-              {t(
-                tekster.underholdskostnadPerBarn(
-                  resultat.barnetsAlder,
-                  resultat.underholdskostnad
-                )
-              )}
-            </ListItem>
-          ))}
-        </List>
-        <BodyLong spacing>{t(tekster.innhold3)}</BodyLong>
-        <BodyLong spacing>{t(tekster.innhold4)}</BodyLong>
-        <BodyLong spacing>{t(tekster.innhold5)}</BodyLong>
-        <div className="flex justify-end gap-4">
+        <BodyLong spacing>{t(tekster.hvordanAvtale)}</BodyLong>
+        <div className="flex gap-4 justify-start mb-6">
           <Button
             as="a"
             href="https://www.nav.no/fyllut/nav550060?sub=paper"
@@ -69,6 +66,35 @@ export const ResultDisplay = ({ data, ref }: ResultDisplayProps) => {
             {t(tekster.søkNavOmFastsetting)}
           </Button>
         </div>
+        <BodyLong spacing>{t(tekster.omtrentligSum)}</BodyLong>
+        <BodyLong spacing>{t(tekster.callToActionGammelKalkulator)}</BodyLong>
+        <ExpansionCard aria-labelledby="detaljer" size="small">
+          <ExpansionCardHeader>
+            <ExpansionCardTitle as="h3" size="small" id="detaljer">
+              {t(tekster.detaljer.overskrift)}
+            </ExpansionCardTitle>
+          </ExpansionCardHeader>
+          <ExpansionCardContent>
+            <BodyLong spacing>
+              {t(tekster.detaljer.underholdskostnadBeskrivelse)}
+            </BodyLong>
+            <List>
+              {data.resultater.map((resultat, index) => (
+                <ListItem key={index}>
+                  {t(
+                    tekster.detaljer.underholdskostnadPerBarn(
+                      resultat.barnetsAlder,
+                      resultat.underholdskostnad
+                    )
+                  )}
+                </ListItem>
+              ))}
+            </List>
+            <BodyLong spacing>
+              {t(tekster.detaljer.underholdskostnadSplitt)}
+            </BodyLong>
+          </ExpansionCardContent>
+        </ExpansionCard>
       </Alert>
     </div>
   );
@@ -90,47 +116,54 @@ const tekster = definerTekster({
     en: "This means that you should not pay any child support. This may be because you and the other parent have shared custody equally, often in combination with a low difference in income.",
     nn: "Det betyr at du ikke skal betale noe i fostringstilskot. Det kan være fordi du og den andre forelderen har delt samvær likt mellom dere, ofte i kombinasjon at differansen mellom inntektene deres er lav.",
   },
-  innhold1: {
+  hvordanAvtale: {
     nb: "Barnebidraget avtaler du med den andre forelderen eller søker Nav om hjelp til å fastsette.",
     en: "The child support is agreed upon with the other parent or sought by Nav to determine.",
     nn: "Fostringstilskotet avtaler du med den andre forelderen eller søkjer Nav om hjelp til å fastsettje.",
   },
-  innhold2: {
-    nb: `Det viktigste grunnlaget for beregningen er hva et barn koster – også kjent som underholdskostnader. Disse summene hentes fra SIFOs referansebudsjetter, og oppdateres hvert år. Kostnaden i deres tilfelle er:`,
-    en: `The most important basis for the calculation is what a child costs – also known as child support costs. These amounts are taken from SIFOs reference budgets and are updated annually. The cost in their case is:`,
-    nn: `Det viktigaste grunnlaget for beregningen er kva eit barn kostar – også kjent som underholdskostnadar. Disse summane hentes frå SIFOs referansebudsjettar, og oppdateres kvart år. Kostnaden i deires tilfelle er:`,
+  detaljer: {
+    overskrift: {
+      nb: "Hvordan bidraget er beregnet",
+      en: "How the child support is calculated",
+      nn: "Korleis fostringstilskotet er rekna ut",
+    },
+    underholdskostnadBeskrivelse: {
+      nb: `Det viktigste grunnlaget for beregningen er hva et barn koster – også kjent som underholdskostnader. Disse summene hentes fra SIFOs referansebudsjetter, og oppdateres hvert år. Kostnaden i deres tilfelle er:`,
+      en: `The most important basis for the calculation is what a child costs – also known as child support costs. These amounts are taken from SIFOs reference budgets and are updated annually. The cost in their case is:`,
+      nn: `Det viktigaste grunnlaget for beregningen er kva eit barn kostar – også kjent som underholdskostnadar. Disse summane hentes frå SIFOs referansebudsjettar, og oppdateres kvart år. Kostnaden i deires tilfelle er:`,
+    },
+    underholdskostnadPerBarn: (alder, kostnad) => ({
+      nb: (
+        <>
+          {alder}-åringen koster{" "}
+          <strong>{formatterSum(kostnad as number)}</strong> kroner i måneden.
+        </>
+      ),
+      en: (
+        <>
+          The {alder}-year-old costs{" "}
+          <strong>{formatterSum(kostnad as number)}</strong> per month.
+        </>
+      ),
+      nn: (
+        <>
+          {alder}-åringen kostar{" "}
+          <strong>{formatterSum(kostnad as number)}</strong> kroner i måneden.
+        </>
+      ),
+    }),
+    underholdskostnadSplitt: {
+      nb: "Dette er summen som skal deles mellom deg og den andre forelderen. Hvordan det splittes opp, avhenger av inntekt og samvær, i tillegg til en rekke andre forhold.",
+      en: "This is the amount that should be divided between you and the other parent. How it is split depends on income and custody, in addition to a number of other factors.",
+      nn: "Dette er summen som skal delast mellom deg og den andre forelderen. Kvifor det splittast, avheng av inntekt og samvær, i tillegg til ein rekkje andre forhold.",
+    },
   },
-  underholdskostnadPerBarn: (alder, kostnad) => ({
-    nb: (
-      <>
-        {alder}-åringen koster{" "}
-        <strong>{formatterSum(kostnad as number)}</strong> kroner i måneden.
-      </>
-    ),
-    en: (
-      <>
-        The {alder}-year-old costs{" "}
-        <strong>{formatterSum(kostnad as number)}</strong> per month.
-      </>
-    ),
-    nn: (
-      <>
-        {alder}-åringen kostar{" "}
-        <strong>{formatterSum(kostnad as number)}</strong> kroner i måneden.
-      </>
-    ),
-  }),
-  innhold3: {
-    nb: "Dette er summen som skal deles mellom deg og den andre forelderen. Hvordan det splittes opp, avhenger av inntekt og samvær, i tillegg til en rekke andre forhold.",
-    en: "This is the amount that should be divided between you and the other parent. How it is split depends on income and custody, in addition to a number of other factors.",
-    nn: "Dette er summen som skal delast mellom deg og den andre forelderen. Kvifor det splittast, avheng av inntekt og samvær, i tillegg til ein rekkje andre forhold.",
-  },
-  innhold4: {
+  omtrentligSum: {
     nb: "Forslaget er basert på noen få opplysninger, som gjør det enkelt å få en omtrentlig sum.",
     en: "The proposal is based on a few pieces of information, making it easy to get an approximate sum.",
     nn: "Forslaget er basert på nokon få opplysningar, som gjør det enkelt å få ein omtrentleg sum.",
   },
-  innhold5: {
+  callToActionGammelKalkulator: {
     nb: (
       <>
         Om du ønsker en mer presis kalkulering, kan du bruke{" "}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -63,7 +63,7 @@ export function Layout({ children }: LayoutProps) {
             className="flex-1"
             as="main"
             id="maincontent"
-            width="md"
+            width="xl"
             gutters
           >
             {children}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -47,25 +47,30 @@ export default function Barnebidragskalkulator() {
   };
 
   return (
-    <div className="max-w-xl mx-auto p-4 mt-8">
-      <Heading size="xlarge" level="1" spacing align="center">
-        {t(tekster.overskrift)}
-      </Heading>
+    <>
+      <div className="max-w-xl mx-auto p-4 mt-8">
+        <Heading size="xlarge" level="1" spacing align="center">
+          {t(tekster.overskrift)}
+        </Heading>
 
-      <IntroPanel />
+        <IntroPanel />
 
-      <BidragsForm resultatRef={resultatRef} />
+        <BidragsForm resultatRef={resultatRef} />
 
-      {isValidationErrorResponse(actionData) && (
-        <div className="mt-6">
-          <Alert variant="error">
-            <BodyLong>{actionData.fieldErrors.root}</BodyLong>
-          </Alert>
+        {isValidationErrorResponse(actionData) && (
+          <div className="mt-6">
+            <Alert variant="error">
+              <BodyLong>{actionData.fieldErrors.root}</BodyLong>
+            </Alert>
+          </div>
+        )}
+      </div>
+      {actionData && (
+        <div className="max-w-3xl mx-auto p-4 mt-8">
+          <ResultDisplay data={getResultData()} ref={resultatRef} />
         </div>
       )}
-
-      <ResultDisplay data={getResultData()} ref={resultatRef} />
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Denne PRen gjør et par ting:

- Gjør utregningsboksen (den blå) bredere, så det er plass til mer informasjon i den
- Flytter CTA-knappene lenger opp i teksten
- Flytter utregningsspesifikk informasjon inn i et ExpansionCard

<img width="756" alt="image" src="https://github.com/user-attachments/assets/79b60e31-5744-4a55-a092-d3bcd58a8481" />

<img width="769" alt="image" src="https://github.com/user-attachments/assets/07f1d7aa-6583-4dda-890b-06ea3a619ea3" />
