### PR TITLE
Legg til tracking av beregningsdetaljer-toggle

### DIFF
--- a/app/features/form/ResultDisplay.tsx
+++ b/app/features/form/ResultDisplay.tsx
@@ -13,6 +13,8 @@ import {
   ExpansionCardTitle,
 } from "@navikt/ds-react/ExpansionCard";
 import { ListItem } from "@navikt/ds-react/List";
+import { useRef } from "react";
+import { sporHendelse } from "~/utils/analytics";
 import { definerTekster, useOversettelse } from "~/utils/i18n";
 import { formatterSum } from "~/utils/tall";
 import type { SkjemaResponse } from "./validator";
@@ -23,6 +25,7 @@ type ResultDisplayProps = {
 
 export const ResultDisplay = ({ data, ref }: ResultDisplayProps) => {
   const { t } = useOversettelse();
+  const beregningsdetaljerAntallSporingerRef = useRef(0);
   if (!data) {
     return null;
   }
@@ -74,7 +77,20 @@ export const ResultDisplay = ({ data, ref }: ResultDisplayProps) => {
           </Button>
         </div>
         <BodyLong spacing>{t(tekster.callToActionGammelKalkulator)}</BodyLong>
-        <ExpansionCard aria-labelledby="detaljer" size="small">
+        <ExpansionCard
+          aria-labelledby="detaljer"
+          size="small"
+          onToggle={(open) => {
+            // Vi ønsker å unngå å spore at man åpner og lukker og åpner og lukker osv.
+            if (beregningsdetaljerAntallSporingerRef.current > 2) {
+              return;
+            }
+            beregningsdetaljerAntallSporingerRef.current++;
+            open
+              ? sporHendelse("beregningsdetaljer utvidet")
+              : sporHendelse("beregningsdetaljer kollapset");
+          }}
+        >
           <ExpansionCardHeader>
             <ExpansionCardTitle as="h3" size="small" id="detaljer">
               {t(tekster.detaljer.overskrift)}

--- a/app/utils/analytics.tsx
+++ b/app/utils/analytics.tsx
@@ -2,7 +2,9 @@ type EventType =
   | "skjema validering feilet"
   | "skjema innsending feilet"
   | "skjema fullført"
-  | "samværsgrad justert";
+  | "samværsgrad justert"
+  | "beregningsdetaljer utvidet"
+  | "beregningsdetaljer kollapset";
 
 /**
  * Sporer en hendelse


### PR DESCRIPTION
Denne PRen legger til sporing av når man åpner (og lukker) beregningsdetaljene. 

Jeg har også lagt til en sjekk for at man ikke åpner og lukker og åpner og lukker, da vi er mer interessert i hvor mange som åpner den (og evnt lukker den igjen) enn å tracke faktisk antallet åpninger (f.eks. om noen åpner og lukker og åpner og lukker fordi de har en nervøs twitch eller noe).