### PR TITLE
Deploy til prod via releases

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
         id: docker-push-dev
         with:
           team: bidrag
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}F
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           build_secrets: NODE_AUTH_TOKEN=${{ secrets.READER_TOKEN }}
       - name: Deploy to nais
@@ -32,30 +32,3 @@ jobs:
           IMAGE: ${{ steps.docker-push-dev.outputs.image }}
           RESOURCE: .nais/naiserator.yml
           VARS: .nais/dev.json
-  deploy-prod:
-    name: Deploy to prod
-    needs: [deploy-dev]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          persist-credentials: false
-      - name: Build and push docker image to GAR
-        uses: nais/docker-build-push@main
-        id: docker-push-prod
-        with:
-          team: bidrag
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          build_secrets: NODE_AUTH_TOKEN=${{ secrets.READER_TOKEN }}
-      - name: Deploy to nais
-        uses: nais/deploy/actions/deploy@v2
-        env:
-          CLUSTER: prod-gcp
-          IMAGE: ${{ steps.docker-push-prod.outputs.image }}
-          RESOURCE: .nais/naiserator.yml
-          VARS: .nais/prod.json

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
         id: docker-push-dev
         with:
           team: bidrag
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}F
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           build_secrets: NODE_AUTH_TOKEN=${{ secrets.READER_TOKEN }}
       - name: Deploy to nais

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy
+name: Bygg og deploy
 on:
   workflow_dispatch:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy-dev:
-    name: Deploy to dev
+    name: Deploy til dev
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
-      - name: Build and push docker image to GAR
+      - name: Bygg og push docker image til GAR
         uses: nais/docker-build-push@main
         id: docker-push-dev
         with:
@@ -25,7 +25,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           build_secrets: NODE_AUTH_TOKEN=${{ secrets.READER_TOKEN }}
-      - name: Deploy to nais
+      - name: Deploy til nais
         uses: nais/deploy/actions/deploy@v2
         env:
           CLUSTER: dev-gcp

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,32 @@
+name: Deploy Release
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy-prod:
+    name: Deploy to prod
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+      - name: Build and push docker image to GAR
+        uses: nais/docker-build-push@main
+        id: docker-push-prod
+        with:
+          team: bidrag
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          build_secrets: NODE_AUTH_TOKEN=${{ secrets.READER_TOKEN }}
+      - name: Deploy to nais
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: prod-gcp
+          IMAGE: ${{ steps.docker-push-prod.outputs.image }}
+          RESOURCE: .nais/naiserator.yml
+          VARS: .nais/prod.json

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,11 +1,11 @@
-name: Deploy Release
+name: Deploy release til prod
 on:
   release:
     types: [published]
 
 jobs:
   deploy-prod:
-    name: Deploy to prod
+    name: Deploy til prod
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
-      - name: Build and push docker image to GAR
+      - name: Bygg og push docker image til GAR
         uses: nais/docker-build-push@main
         id: docker-push-prod
         with:
@@ -23,7 +23,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           build_secrets: NODE_AUTH_TOKEN=${{ secrets.READER_TOKEN }}
-      - name: Deploy to nais
+      - name: Deploy til nais
         uses: nais/deploy/actions/deploy@v2
         env:
           CLUSTER: prod-gcp

--- a/.github/workflows/manual-deploy-dev.yml
+++ b/.github/workflows/manual-deploy-dev.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.inputs.branch }}
-      - name: Build and push docker image to GAR
+      - name: Bygg og push docker image til GAR
         uses: nais/docker-build-push@main
         id: docker-push-dev
         with:

--- a/.github/workflows/manual-deploy-dev.yml
+++ b/.github/workflows/manual-deploy-dev.yml
@@ -1,0 +1,38 @@
+name: Manuell deploy til dev
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branchen du vil deploye"
+        required: true
+        default: "main"
+        type: string
+
+jobs:
+  deploy-dev:
+    name: Deploy to dev
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.branch }}
+      - name: Build and push docker image to GAR
+        uses: nais/docker-build-push@main
+        id: docker-push-dev
+        with:
+          team: bidrag
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}F
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          build_secrets: NODE_AUTH_TOKEN=${{ secrets.READER_TOKEN }}
+      - name: Deploy to nais
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          IMAGE: ${{ steps.docker-push-dev.outputs.image }}
+          RESOURCE: .nais/naiserator.yml
+          VARS: .nais/dev.json

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ Kalkulatoren er under aktiv utvikling, så det er ikke sikkert at alt fungerer s
 
 Man deployer automatisk til dev- og prod-miljøene når man merger en pull request til main-branchen.
 
+### Manuell deploy til dev
+
+For å deploye en spesifikk branch til dev-miljøet:
+1. Gå til "Actions" i GitHub
+2. Velg "Manuell deploy til dev" fra workflows-listen
+3. Klikk "Run workflow"
+4. Velg branchen du vil deploye
+5. Klikk "Run workflow"
+
+### Deploy til prod
+
+Man kan deploye direkte til prod ved å lage en ny release i GitHub:
+1. Gå til "Releases" i GitHub
+2. Klikk på "Create a new release"
+3. Velg en tag (f.eks. v1.2.3)
+4. Skriv en tittel og beskrivelse av endringene
+5. Klikk "Publish release"
+
+Når releasen er publisert, vil applikasjonen automatisk deployes til prod-miljøet.
+
 **Dev-miljøet finner du på https://bidragskalkulator-v2.ekstern.dev.nav.no**
 
 **Prod-miljøet finner du på https://barnebidragskalkulator.nav.no**


### PR DESCRIPTION
Denne pull request-en introduserer flere endringer i GitHub-workflowene og dokumentasjonen for å forenkle utrullingsprosessen. De viktigste endringene inkluderer å legge til en ny workflow for manuell utrulling til utviklingsmiljøet, opprette en workflow for utrulling ved publisering av en release, samt oppdatere dokumentasjonen for å reflektere disse endringene.

### Endringer i workflows:

* [`.github/workflows/build-and-deploy.yml`](diffhunk://#diff-ecad2183af1362d9d99f4a33e7491c1970c92255c3c318e688ece549ec91fe33L35-L61): Fjernet `deploy-prod`-jobben for å forenkle workflowen.
* [`.github/workflows/deploy-release.yml`](diffhunk://#diff-e43b9607f56d176fa480e8d84498993ba46a25fbcd6bb78355ae4e84a6a04754R1-R32): Lagt til en ny workflow som deployer til produksjon når en release publiseres.
* [`.github/workflows/manual-deploy-dev.yml`](diffhunk://#diff-664cc68242c4912781c3a1efdd5f3631d393f8d65b1eb139cee12c3444bf5eb2R1-R38): Introdusert en ny workflow for manuell utrulling til utviklingsmiljøet.

### Oppdateringer i dokumentasjon:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11-R30): Oppdatert med instruksjoner for manuell utrulling til utviklingsmiljøet og utrulling til produksjon via GitHub releases.