### PR TITLE
Forbedre søkeparameter parsing

### DIFF
--- a/app/features/form/Resultatpanel.tsx
+++ b/app/features/form/Resultatpanel.tsx
@@ -53,8 +53,6 @@ export const Resultatpanel = ({ data, ref, formData }: ResultatpanelProps) => {
     searchParams.append("inntektForelder1", formData.inntektForelder1);
     searchParams.append("inntektForelder2", formData.inntektForelder2);
 
-    console.log(searchParams.toString());
-
     return `${window.location.origin}${
       window.location.pathname
     }?${searchParams.toString()}`;

--- a/app/features/form/useBidragsForm.ts
+++ b/app/features/form/useBidragsForm.ts
@@ -1,41 +1,17 @@
 import { useForm } from "@rvf/react-router";
 import { type RefObject } from "react";
-import { useSearchParams } from "react-router";
 import { sporHendelse } from "~/utils/analytics";
 import { useOversettelse } from "~/utils/i18n";
-import { lagValidatorMedSpråk } from "./validator";
-
-const hentVerdierFraSearchParams = (searchParams: URLSearchParams) => {
-  const barn: Array<{ alder: string; samværsgrad: string; bostatus: string }> =
-    [];
-  let currentIndex = 0;
-
-  while (searchParams.has(`barn[${currentIndex}].alder`)) {
-    barn.push({
-      alder: searchParams.get(`barn[${currentIndex}].alder`) || "",
-      samværsgrad:
-        searchParams.get(`barn[${currentIndex}].samværsgrad`) || "15",
-      bostatus: searchParams.get(`barn[${currentIndex}].bostatus`) || "",
-    });
-    currentIndex++;
-  }
-
-  return {
-    barn:
-      barn.length > 0 ? barn : [{ alder: "", samværsgrad: "15", bostatus: "" }],
-    inntektForelder1: searchParams.get("inntektForelder1") || "",
-    inntektForelder2: searchParams.get("inntektForelder2") || "",
-  };
-};
+import { useValiderteSøkeparametre } from "./useValiderteSøkeparametre";
+import { lagValidatorMedSpråk, søkeparametreSchema } from "./validator";
 
 export const useBidragsform = (
   resultatRef: RefObject<HTMLDivElement | null>
 ) => {
   const { språk } = useOversettelse();
   const validator = lagValidatorMedSpråk(språk);
-  const [searchParams] = useSearchParams();
 
-  const searchParamsVerdier = hentVerdierFraSearchParams(searchParams);
+  const validerteSøkeparametre = useValiderteSøkeparametre(søkeparametreSchema);
 
   // Valider at verdiene fra URL-en er gyldige
   let defaultValues = {
@@ -44,22 +20,11 @@ export const useBidragsform = (
     inntektForelder2: "",
   };
 
-  try {
-    validator.validate(searchParamsVerdier);
-    defaultValues = searchParamsVerdier;
-  } catch (e) {
-    // Bruk standard verdier hvis URL-parametrene er ugyldige
-    sporHendelse("skjema validering feilet", {
-      kilde: "url-parametere",
-      feil: String(e),
-    });
-  }
-
   const form = useForm({
     validator,
     submitSource: "state",
     method: "post",
-    defaultValues,
+    defaultValues: validerteSøkeparametre ?? defaultValues,
     onSubmitSuccess: () => {
       resultatRef.current?.focus({ preventScroll: true });
       resultatRef.current?.scrollIntoView({

--- a/app/features/form/useValiderteSøkeparametre.ts
+++ b/app/features/form/useValiderteSøkeparametre.ts
@@ -1,0 +1,51 @@
+import { useSearchParams } from "react-router";
+import { ZodSchema } from "zod";
+
+/**
+ * Henter ut en parset versjon av søkeparametrene i URL-en.
+ *
+ * @param schema Zod-schema for å validere søkeparametrene
+ * @returns Parset objekt eller null hvis valideringen feiler
+ */
+export function useValiderteSøkeparametre<T>(schema: ZodSchema<T>) {
+  const [søkeparameterString] = useSearchParams();
+  const søkeparametre = parseSøkeparametreTilObjekt(
+    søkeparameterString.toString()
+  );
+
+  const resultat = schema.safeParse(søkeparametre);
+
+  if (!resultat.success) {
+    return null;
+  }
+
+  return resultat.data;
+}
+
+/** Intern støttefunksjon for å gjøre om en søkeparameter-streng til et objekt */
+function parseSøkeparametreTilObjekt(search: string) {
+  const params = new URLSearchParams(search);
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of params.entries()) {
+    const path = key.replace(/\]/g, "").split(/\[|\./); // støtter både items[0].id og items[0][id]
+
+    let current: any = result;
+    path.forEach((segment, index) => {
+      const isLast = index === path.length - 1;
+      const nextSegment = path[index + 1];
+      const isArray = /^\d+$/.test(nextSegment || "");
+
+      if (isLast) {
+        current[segment] = value;
+      } else {
+        if (current[segment] == null) {
+          current[segment] = isArray ? [] : {};
+        }
+        current = current[segment];
+      }
+    });
+  }
+
+  return result;
+}

--- a/app/features/form/useValiderteSøkeparametre.ts
+++ b/app/features/form/useValiderteSøkeparametre.ts
@@ -1,5 +1,6 @@
 import { useSearchParams } from "react-router";
 import { ZodSchema } from "zod";
+import { sporHendelse } from "~/utils/analytics";
 
 /**
  * Henter ut en parset versjon av søkeparametrene i URL-en.
@@ -16,6 +17,9 @@ export function useValiderteSøkeparametre<T>(schema: ZodSchema<T>) {
   const resultat = schema.safeParse(søkeparametre);
 
   if (!resultat.success) {
+    sporHendelse("delbar lenke feilet validering", {
+      feil: resultat.error.format(),
+    });
     return null;
   }
 

--- a/app/features/form/useValiderteSøkeparametre.ts
+++ b/app/features/form/useValiderteSøkeparametre.ts
@@ -10,46 +10,53 @@ import { sporHendelse } from "~/utils/analytics";
  */
 export function useValiderteSøkeparametre<T>(schema: ZodSchema<T>) {
   const [søkeparameterString] = useSearchParams();
-  const søkeparametre = parseSøkeparametreTilObjekt(
-    søkeparameterString.toString()
-  );
+  try {
+    const søkeparametre = parseSøkeparametreTilObjekt(
+      søkeparameterString.toString()
+    );
 
-  const resultat = schema.safeParse(søkeparametre);
+    const resultat = schema.safeParse(søkeparametre);
 
-  if (!resultat.success) {
+    if (!resultat.success) {
+      sporHendelse("delbar lenke feilet validering", {
+        feil: resultat.error.format(),
+      });
+      return null;
+    }
+
+    return resultat.data;
+  } catch (e) {
     sporHendelse("delbar lenke feilet validering", {
-      feil: resultat.error.format(),
+      feil: String(e),
     });
     return null;
   }
-
-  return resultat.data;
 }
 
 /** Intern støttefunksjon for å gjøre om en søkeparameter-streng til et objekt */
-function parseSøkeparametreTilObjekt(search: string) {
-  const params = new URLSearchParams(search);
-  const result: Record<string, unknown> = {};
+function parseSøkeparametreTilObjekt(søkeparameterstring: string) {
+  const søkeparametre = new URLSearchParams(søkeparameterstring);
+  const resultat: Record<string, unknown> = {};
 
-  for (const [key, value] of params.entries()) {
-    const path = key.replace(/\]/g, "").split(/\[|\./); // støtter både items[0].id og items[0][id]
+  for (const [nøkkel, verdi] of søkeparametre.entries()) {
+    const sti = nøkkel.replace(/\]/g, "").split(/\[|\./); // støtter både items[0].id og items[0][id]
 
-    let current: any = result;
-    path.forEach((segment, index) => {
-      const isLast = index === path.length - 1;
-      const nextSegment = path[index + 1];
-      const isArray = /^\d+$/.test(nextSegment || "");
+    let nåværende: any = resultat;
+    sti.forEach((segment, index) => {
+      const erSiste = index === sti.length - 1;
+      const nesteSegment = sti[index + 1];
+      const erArray = /^\d+$/.test(nesteSegment || "");
 
-      if (isLast) {
-        current[segment] = value;
+      if (erSiste) {
+        nåværende[segment] = verdi;
       } else {
-        if (current[segment] == null) {
-          current[segment] = isArray ? [] : {};
+        if (nåværende[segment] == null) {
+          nåværende[segment] = erArray ? [] : {};
         }
-        current = current[segment];
+        nåværende = nåværende[segment];
       }
     });
   }
 
-  return result;
+  return resultat;
 }

--- a/app/features/form/validator.ts
+++ b/app/features/form/validator.ts
@@ -102,6 +102,18 @@ const tekster = definerTekster({
   },
 });
 
+export const søkeparametreSchema = z.object({
+  barn: z.array(
+    z.object({
+      alder: z.string(),
+      samværsgrad: z.string(),
+      bostatus: z.enum(["HOS_FORELDER_1", "DELT_BOSTED", "HOS_FORELDER_2"]),
+    })
+  ),
+  inntektForelder1: z.string(),
+  inntektForelder2: z.string(),
+});
+
 export function lagSkjemaSchema(språk: Språk) {
   return z.object({
     barn: z

--- a/app/utils/analytics.tsx
+++ b/app/utils/analytics.tsx
@@ -5,7 +5,8 @@ type EventType =
   | "samværsgrad justert"
   | "beregningsdetaljer utvidet"
   | "beregningsdetaljer kollapset"
-  | "delbar lenke kopiert";
+  | "delbar lenke kopiert"
+  | "delbar lenke feilet validering";
 
 /**
  * Sporer en hendelse


### PR DESCRIPTION
Denne PRen forbedrer måten vi henter inn søkeparametre fra URLen på, ved å bruke zod til å validere det. Om søkeparameterne ikke følger vårt schema, så ignorerer vi dem bare.

Vi gjør ikke verdens mest avanserte validering her, så du kan sende inn ugyldige verdier (f.eks. alder 200 eller abc), men da vil man få valideringsfeil når man prøver å submitte.