### PR TITLE
Returner tidlig om det ikke er noen søkeparametre

### DIFF
--- a/app/features/form/useValiderteSøkeparametre.ts
+++ b/app/features/form/useValiderteSøkeparametre.ts
@@ -10,6 +10,10 @@ import { sporHendelse } from "~/utils/analytics";
  */
 export function useValiderteSøkeparametre<T>(schema: ZodSchema<T>) {
   const [søkeparameterString] = useSearchParams();
+  if (!søkeparameterString) {
+    return null;
+  }
+
   try {
     const søkeparametre = parseSøkeparametreTilObjekt(
       søkeparameterString.toString()
@@ -18,17 +22,11 @@ export function useValiderteSøkeparametre<T>(schema: ZodSchema<T>) {
     const resultat = schema.safeParse(søkeparametre);
 
     if (!resultat.success) {
-      sporHendelse("delbar lenke feilet validering", {
-        feil: resultat.error.format(),
-      });
       return null;
     }
 
     return resultat.data;
   } catch (e) {
-    sporHendelse("delbar lenke feilet validering", {
-      feil: String(e),
-    });
     return null;
   }
 }

--- a/app/utils/analytics.tsx
+++ b/app/utils/analytics.tsx
@@ -5,8 +5,7 @@ type EventType =
   | "samværsgrad justert"
   | "beregningsdetaljer utvidet"
   | "beregningsdetaljer kollapset"
-  | "delbar lenke kopiert"
-  | "delbar lenke feilet validering";
+  | "delbar lenke kopiert";
 
 /**
  * Sporer en hendelse


### PR DESCRIPTION
Denne PRen fjerner tracking om man ikke har noen søkeparametre, eller om det ikke følger gitt format. Vi har bl.a. en greie som heter ?index som legges til av og til, som jeg ikke vil at skal deales med.