### PR TITLE
Ikke spør om branchnavn to ganger

### DIFF
--- a/.github/workflows/manual-deploy-dev.yml
+++ b/.github/workflows/manual-deploy-dev.yml
@@ -1,12 +1,6 @@
 name: Manuell deploy til dev
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branchen du vil deploye"
-        required: true
-        default: "main"
-        type: string
 
 jobs:
   deploy-dev:
@@ -20,7 +14,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.ref }}
       - name: Bygg og push docker image til GAR
         uses: nais/docker-build-push@main
         id: docker-push-dev


### PR DESCRIPTION
Denne PRen fjerner inputfeltet man ser i "Manuell deploy til dev" actionen, slik at man ikke trenger å spesifisere branch to ganger.