### PR TITLE
Fiks feilhåndtering

### DIFF
--- a/app/config/env.server.ts
+++ b/app/config/env.server.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 const envSchema = z.object({
   SERVER_URL: z.string().url(),
   ENVIRONMENT: z.enum(["dev", "prod"]),
-  UMAMI_WEBSITE_ID: z.string(), // TODO: Legg til UUID-validering
+  UMAMI_WEBSITE_ID: z.string().uuid(),
   INGRESS: z.string().url(),
 });
 

--- a/app/config/env.server.ts
+++ b/app/config/env.server.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 
 const envSchema = z.object({
-  SERVER_URL: z.string().url(),
-  ENVIRONMENT: z.enum(["dev", "prod"]),
-  UMAMI_WEBSITE_ID: z.string().uuid(),
-  INGRESS: z.string().url(),
+  SERVER_URL: z.string().url().describe("URL til APIet vårt"),
+  ENVIRONMENT: z.enum(["dev", "prod"]).describe("Dev for Q-miljøet og prod"),
+  UMAMI_WEBSITE_ID: z
+    .string()
+    .describe("ID for umami (sporingsverktøyet vårt)"),
+  INGRESS: z.string().url().describe("Hvilken URL tjenesten kjører på"),
 });
 
 const envParse = envSchema.safeParse(process.env);

--- a/app/config/publicEnv.ts
+++ b/app/config/publicEnv.ts
@@ -1,0 +1,12 @@
+const isServer = typeof process !== "undefined";
+const miljøvariabler = isServer ? process.env : import.meta.env;
+
+/**
+ * Offentlig tilgjengelige miljøvariabler.
+ *
+ * Disse er tilgjengelige på klientsiden, og skal ikke inneholde sensitiv informasjon.
+ */
+export const publicEnv = {
+  UMAMI_WEBSITE_ID: miljøvariabler.UMAMI_WEBSITE_ID,
+  ENVIRONMENT: miljøvariabler.ENVIRONMENT,
+};

--- a/app/features/feilhåndtering/404.tsx
+++ b/app/features/feilhåndtering/404.tsx
@@ -1,45 +1,61 @@
-import { BodyShort, Box, Heading, Link, List } from "@navikt/ds-react";
-import { definerTekster, useOversettelse } from "~/utils/i18n";
+import { BugIcon } from "@navikt/aksel-icons";
+import {
+  BodyShort,
+  Box,
+  Button,
+  Heading,
+  Link,
+  List,
+  Page,
+  VStack,
+} from "@navikt/ds-react";
 
 export function NotFound() {
-  const { t } = useOversettelse();
   return (
     <Box paddingBlock="20 16" data-aksel-template="404-v2">
-      <div>
-        <Heading level="1" size="large" spacing>
-          {t(tekster.overskrift)}
-        </Heading>
-        <BodyShort>{t(tekster.innhold)}</BodyShort>
-        <List>
-          <List.Item>{t(tekster.brukSøkEllerMeny)}</List.Item>
-          <List.Item>
-            <Link href="/">{t(tekster.gåTilBarnebidrag)}</Link>
-          </List.Item>
-        </List>
-      </div>
+      <Page.Block as="main" width="xl" gutters>
+        <Box paddingBlock="20 16" data-aksel-template="404-v2">
+          <VStack gap="16">
+            <VStack gap="12" align="start">
+              <div>
+                <Heading level="1" size="large" spacing>
+                  Beklager, vi fant ikke siden
+                </Heading>
+                <BodyShort>
+                  Denne siden kan være slettet eller flyttet, eller det er en
+                  feil i lenken.
+                </BodyShort>
+                <List>
+                  <List.Item>Bruk gjerne søket eller menyen</List.Item>
+                  <List.Item>
+                    <Link href="https://www.nav.no">Gå til forsiden</Link>
+                  </List.Item>
+                </List>
+              </div>
+              <Button as="a" href="https://barnebidragskalkulator.nav.no">
+                Gå til barnebidragskalkulatoren
+              </Button>
+              <Link href="https://www.nav.no/person/kontakt-oss/tilbakemeldinger/feil-og-mangler">
+                <BugIcon aria-hidden />
+                Meld gjerne fra om at lenken ikke virker
+              </Link>
+            </VStack>
+
+            <div>
+              <Heading level="2" size="large" spacing>
+                Page not found
+              </Heading>
+              <BodyShort spacing>
+                The page you requested cannot be found.
+              </BodyShort>
+              <BodyShort>
+                Go to the <Link href="https://www.nav.no">front page</Link>, or
+                use one of the links in the menu.
+              </BodyShort>
+            </div>
+          </VStack>
+        </Box>
+      </Page.Block>
     </Box>
   );
 }
-
-const tekster = definerTekster({
-  overskrift: {
-    nb: "Beklager, vi fant ikke siden",
-    en: "Sorry, we couldn't find the page",
-    nn: "Beklager, vi fant ikke sida",
-  },
-  innhold: {
-    nb: "Denne siden kan være slettet eller flyttet, eller det er en feil i lenken.",
-    en: "The page may have been deleted or moved, or there is an error in the link.",
-    nn: "Sidene kan ha blitt sletta eller flytta, eller det er ein feil i lenken.",
-  },
-  gåTilBarnebidrag: {
-    nb: "Gå til barnebidragskalkulatoren",
-    en: "Go to child support calculator",
-    nn: "Gå til fostringstilskotkalkulatoren",
-  },
-  brukSøkEllerMeny: {
-    nb: "Bruk gjerne søket eller menyen",
-    en: "Use the search or menu",
-    nn: "Bruk gjerne søket eller menyen",
-  },
-});

--- a/app/features/feilhåndtering/404.tsx
+++ b/app/features/feilhåndtering/404.tsx
@@ -6,56 +6,49 @@ import {
   Heading,
   Link,
   List,
-  Page,
   VStack,
 } from "@navikt/ds-react";
 
 export function NotFound() {
   return (
     <Box paddingBlock="20 16" data-aksel-template="404-v2">
-      <Page.Block as="main" width="xl" gutters>
-        <Box paddingBlock="20 16" data-aksel-template="404-v2">
-          <VStack gap="16">
-            <VStack gap="12" align="start">
-              <div>
-                <Heading level="1" size="large" spacing>
-                  Beklager, vi fant ikke siden
-                </Heading>
-                <BodyShort>
-                  Denne siden kan være slettet eller flyttet, eller det er en
-                  feil i lenken.
-                </BodyShort>
-                <List>
-                  <List.Item>Bruk gjerne søket eller menyen</List.Item>
-                  <List.Item>
-                    <Link href="https://www.nav.no">Gå til forsiden</Link>
-                  </List.Item>
-                </List>
-              </div>
-              <Button as="a" href="https://barnebidragskalkulator.nav.no">
-                Gå til barnebidragskalkulatoren
-              </Button>
-              <Link href="https://www.nav.no/person/kontakt-oss/tilbakemeldinger/feil-og-mangler">
-                <BugIcon aria-hidden />
-                Meld gjerne fra om at lenken ikke virker
-              </Link>
-            </VStack>
+      <VStack gap="16">
+        <VStack gap="12" align="start">
+          <div>
+            <Heading level="1" size="large" spacing>
+              Beklager, vi fant ikke siden
+            </Heading>
+            <BodyShort>
+              Denne siden kan være slettet eller flyttet, eller det er en feil i
+              lenken.
+            </BodyShort>
+            <List>
+              <List.Item>Bruk gjerne søket eller menyen</List.Item>
+              <List.Item>
+                <Link href="https://www.nav.no">Gå til forsiden</Link>
+              </List.Item>
+            </List>
+          </div>
+          <Button as="a" href="https://barnebidragskalkulator.nav.no">
+            Gå til barnebidragskalkulatoren
+          </Button>
+          <Link href="https://www.nav.no/person/kontakt-oss/tilbakemeldinger/feil-og-mangler">
+            <BugIcon aria-hidden />
+            Meld gjerne fra om at lenken ikke virker
+          </Link>
+        </VStack>
 
-            <div>
-              <Heading level="2" size="large" spacing>
-                Page not found
-              </Heading>
-              <BodyShort spacing>
-                The page you requested cannot be found.
-              </BodyShort>
-              <BodyShort>
-                Go to the <Link href="https://www.nav.no">front page</Link>, or
-                use one of the links in the menu.
-              </BodyShort>
-            </div>
-          </VStack>
-        </Box>
-      </Page.Block>
+        <div>
+          <Heading level="2" size="large" spacing>
+            Page not found
+          </Heading>
+          <BodyShort spacing>The page you requested cannot be found.</BodyShort>
+          <BodyShort>
+            Go to the <Link href="https://www.nav.no">front page</Link>, or use
+            one of the links in the menu.
+          </BodyShort>
+        </div>
+      </VStack>
     </Box>
   );
 }

--- a/app/features/feilhåndtering/500.tsx
+++ b/app/features/feilhåndtering/500.tsx
@@ -1,117 +1,96 @@
-import { BodyShort, Box, Heading, HGrid, Link, List } from "@navikt/ds-react";
-import { definerTekster, useOversettelse } from "~/utils/i18n";
+import {
+  BodyShort,
+  Box,
+  Button,
+  Heading,
+  HGrid,
+  Link,
+  List,
+  Page,
+  VStack,
+} from "@navikt/ds-react";
 
 type InternalServerErrorProps = {
   stack?: string;
 };
 export function InternalServerError({ stack }: InternalServerErrorProps) {
-  const { t } = useOversettelse();
   return (
     <Box paddingBlock="20 16">
-      <HGrid columns="minmax(auto,600px)" data-aksel-template="500-v2">
-        <BodyShort textColor="subtle" size="small">
-          {t(tekster.underoverskrift)}
-        </BodyShort>
-        <Heading level="1" size="large" spacing>
-          {t(tekster.overskrift)}
-        </Heading>
-        {/* Tekster bør tilpasses den aktuelle 500-feilen. Teksten under er for en generisk 500-feil. */}
-        <BodyShort spacing>{t(tekster.innhold)}</BodyShort>
-        <BodyShort>Du kan prøve å</BodyShort>
-        <List>
-          <List.Item>{t(tekster.prøvÅLasteSidenPåNytt)}</List.Item>
-          {history && history.length > 1 && (
-            <List.Item>
-              <Link href="#" onClick={() => history.back()}>
-                {t(tekster.gåTilbakeTilForrigeSide)}
-              </Link>
-            </List.Item>
-          )}
-        </List>
-        <BodyShort>{t(tekster.kontaktOss)}.</BodyShort>
-        {stack && (
-          <pre className="w-full p-4 overflow-x-auto">
-            <code>{stack}</code>
-          </pre>
-        )}
-      </HGrid>
+      <Page.Block as="main" width="xl" gutters>
+        <Box paddingBlock="20 8">
+          <HGrid columns="minmax(auto,600px)" data-aksel-template="500-v2">
+            <VStack gap="16">
+              <VStack gap="12" align="start">
+                <div>
+                  <BodyShort textColor="subtle" size="small">
+                    Statuskode 500
+                  </BodyShort>
+                  <Heading level="1" size="large" spacing>
+                    Beklager, noe gikk galt.
+                  </Heading>
+                  <BodyShort spacing>
+                    En teknisk feil på våre servere gjør at siden er
+                    utilgjengelig. Dette skyldes ikke noe du gjorde.
+                  </BodyShort>
+                  <BodyShort>Du kan prøve å</BodyShort>
+                  <List>
+                    <List.Item>
+                      vente noen minutter og{" "}
+                      <Link href="#" onClick={() => location.reload()}>
+                        laste siden på nytt
+                      </Link>
+                    </List.Item>
+                    <List.Item>
+                      <Link href="#" onClick={() => history.back()}>
+                        gå tilbake til forrige side
+                      </Link>
+                    </List.Item>
+                  </List>
+                  <BodyShort>
+                    Hvis problemet vedvarer, kan du{" "}
+                    <Link href="https://nav.no/kontaktoss" target="_blank">
+                      kontakte oss (åpnes i ny fane)
+                    </Link>
+                    .
+                  </BodyShort>
+                </div>
+
+                {stack && (
+                  <div>
+                    <Heading level="2" size="small">
+                      Stack trace
+                    </Heading>
+                    <BodyShort size="small" textColor="subtle" className="mb-2">
+                      For lokal debugging:
+                    </BodyShort>
+                    <code className="block bg-gray-100 p-2 rounded-md">
+                      <pre className="whitespace-pre-wrap text-sm">{stack}</pre>
+                    </code>
+                  </div>
+                )}
+
+                <Button>Gå til Min side</Button>
+              </VStack>
+
+              <div>
+                <Heading level="1" size="large" spacing>
+                  Something went wrong
+                </Heading>
+                <BodyShort spacing>
+                  This was caused by a technical fault on our servers. Please
+                  refresh this page or try again in a few minutes.{" "}
+                </BodyShort>
+                <BodyShort>
+                  <Link target="_blank" href="https://www.nav.no/kontaktoss/en">
+                    Contact us (opens in new tab)
+                  </Link>{" "}
+                  if the problem persists.
+                </BodyShort>
+              </div>
+            </VStack>
+          </HGrid>
+        </Box>
+      </Page.Block>
     </Box>
   );
 }
-
-const tekster = definerTekster({
-  overskrift: {
-    nb: "Beklager, noe gikk galt.",
-    en: "Sorry, something went wrong.",
-    nn: "Beklager, noko gjekk feil.",
-  },
-  underoverskrift: {
-    nb: "Statuskode 500",
-    en: "Status code 500",
-    nn: "Statuskode 500",
-  },
-  innhold: {
-    nb: "En teknisk feil på våre servere gjør at siden er utilgjengelig. Dette skyldes ikke noe du gjorde.",
-    en: "A technical error on our servers makes the page unavailable. This is not your fault.",
-    nn: "Ein teknisk feil på våre servere gjør at sida er utilgjengelig. Dette skyldes ikkje noko du gjorde.",
-  },
-  prøvÅLasteSidenPåNytt: {
-    nb: (
-      <>
-        vente noen minutter og{" "}
-        <Link href="#" onClick={() => location.reload()}>
-          laste siden på nytt
-        </Link>
-      </>
-    ),
-    en: (
-      <>
-        Wait a few minutes and{" "}
-        <Link href="#" onClick={() => location.reload()}>
-          reload the page
-        </Link>
-      </>
-    ),
-    nn: (
-      <>
-        Vent nokre minutt og{" "}
-        <Link href="#" onClick={() => location.reload()}>
-          last sida på nytt
-        </Link>
-      </>
-    ),
-  },
-  gåTilbakeTilForrigeSide: {
-    nb: "Gå tilbake til forrige side",
-    en: "Go back to the previous page",
-    nn: "Gå tilbake til forrige side",
-  },
-  kontaktOss: {
-    nb: (
-      <>
-        Hvis problemet vedvarer, kan du{" "}
-        <Link href="/kontaktoss" target="_blank">
-          kontakte oss (åpnes i ny fane)
-        </Link>
-        .
-      </>
-    ),
-    en: (
-      <>
-        If the problem persists, you can{" "}
-        <Link href="/kontaktoss" target="_blank">
-          contact us (opens in new tab)
-        </Link>
-      </>
-    ),
-    nn: (
-      <>
-        Hvis problemet vedvarer, kan du{" "}
-        <Link href="/kontaktoss" target="_blank">
-          kontakte oss (åpnes i ny fane)
-        </Link>
-        .
-      </>
-    ),
-  },
-});

--- a/app/features/feilhåndtering/500.tsx
+++ b/app/features/feilhåndtering/500.tsx
@@ -6,7 +6,6 @@ import {
   HGrid,
   Link,
   List,
-  Page,
   VStack,
 } from "@navikt/ds-react";
 
@@ -16,81 +15,77 @@ type InternalServerErrorProps = {
 export function InternalServerError({ stack }: InternalServerErrorProps) {
   return (
     <Box paddingBlock="20 16">
-      <Page.Block as="main" width="xl" gutters>
-        <Box paddingBlock="20 8">
-          <HGrid columns="minmax(auto,600px)" data-aksel-template="500-v2">
-            <VStack gap="16">
-              <VStack gap="12" align="start">
-                <div>
-                  <BodyShort textColor="subtle" size="small">
-                    Statuskode 500
-                  </BodyShort>
-                  <Heading level="1" size="large" spacing>
-                    Beklager, noe gikk galt.
-                  </Heading>
-                  <BodyShort spacing>
-                    En teknisk feil på våre servere gjør at siden er
-                    utilgjengelig. Dette skyldes ikke noe du gjorde.
-                  </BodyShort>
-                  <BodyShort>Du kan prøve å</BodyShort>
-                  <List>
-                    <List.Item>
-                      vente noen minutter og{" "}
-                      <Link href="#" onClick={() => location.reload()}>
-                        laste siden på nytt
-                      </Link>
-                    </List.Item>
-                    <List.Item>
-                      <Link href="#" onClick={() => history.back()}>
-                        gå tilbake til forrige side
-                      </Link>
-                    </List.Item>
-                  </List>
-                  <BodyShort>
-                    Hvis problemet vedvarer, kan du{" "}
-                    <Link href="https://nav.no/kontaktoss" target="_blank">
-                      kontakte oss (åpnes i ny fane)
-                    </Link>
-                    .
-                  </BodyShort>
-                </div>
+      <HGrid columns="minmax(auto,600px)" data-aksel-template="500-v2">
+        <VStack gap="16">
+          <VStack gap="12" align="start">
+            <div>
+              <BodyShort textColor="subtle" size="small">
+                Statuskode 500
+              </BodyShort>
+              <Heading level="1" size="large" spacing>
+                Beklager, noe gikk galt.
+              </Heading>
+              <BodyShort spacing>
+                En teknisk feil på våre servere gjør at siden er utilgjengelig.
+                Dette skyldes ikke noe du gjorde.
+              </BodyShort>
+              <BodyShort>Du kan prøve å</BodyShort>
+              <List>
+                <List.Item>
+                  vente noen minutter og{" "}
+                  <Link href="#" onClick={() => location.reload()}>
+                    laste siden på nytt
+                  </Link>
+                </List.Item>
+                <List.Item>
+                  <Link href="#" onClick={() => history.back()}>
+                    gå tilbake til forrige side
+                  </Link>
+                </List.Item>
+              </List>
+              <BodyShort>
+                Hvis problemet vedvarer, kan du{" "}
+                <Link href="https://nav.no/kontaktoss" target="_blank">
+                  kontakte oss (åpnes i ny fane)
+                </Link>
+                .
+              </BodyShort>
+            </div>
 
-                {stack && (
-                  <div>
-                    <Heading level="2" size="small">
-                      Stack trace
-                    </Heading>
-                    <BodyShort size="small" textColor="subtle" className="mb-2">
-                      For lokal debugging:
-                    </BodyShort>
-                    <code className="block bg-gray-100 p-2 rounded-md">
-                      <pre className="whitespace-pre-wrap text-sm">{stack}</pre>
-                    </code>
-                  </div>
-                )}
-
-                <Button>Gå til Min side</Button>
-              </VStack>
-
+            {stack && (
               <div>
-                <Heading level="1" size="large" spacing>
-                  Something went wrong
+                <Heading level="2" size="small">
+                  Stack trace
                 </Heading>
-                <BodyShort spacing>
-                  This was caused by a technical fault on our servers. Please
-                  refresh this page or try again in a few minutes.{" "}
+                <BodyShort size="small" textColor="subtle" className="mb-2">
+                  For lokal debugging:
                 </BodyShort>
-                <BodyShort>
-                  <Link target="_blank" href="https://www.nav.no/kontaktoss/en">
-                    Contact us (opens in new tab)
-                  </Link>{" "}
-                  if the problem persists.
-                </BodyShort>
+                <code className="block bg-gray-100 p-2 rounded-md">
+                  <pre className="whitespace-pre-wrap text-sm">{stack}</pre>
+                </code>
               </div>
-            </VStack>
-          </HGrid>
-        </Box>
-      </Page.Block>
+            )}
+
+            <Button>Gå til Min side</Button>
+          </VStack>
+
+          <div>
+            <Heading level="1" size="large" spacing>
+              Something went wrong
+            </Heading>
+            <BodyShort spacing>
+              This was caused by a technical fault on our servers. Please
+              refresh this page or try again in a few minutes.{" "}
+            </BodyShort>
+            <BodyShort>
+              <Link target="_blank" href="https://www.nav.no/kontaktoss/en">
+                Contact us (opens in new tab)
+              </Link>{" "}
+              if the problem persists.
+            </BodyShort>
+          </div>
+        </VStack>
+      </HGrid>
     </Box>
   );
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -18,13 +18,15 @@ import {
 
 import { Page } from "@navikt/ds-react";
 import {
+  injectDecoratorClientSide,
   onLanguageSelect,
   setBreadcrumbs,
 } from "@navikt/nav-dekoratoren-moduler";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Route } from "./+types/root";
 import "./app.css";
 import { env } from "./config/env.server";
+import { publicEnv } from "./config/publicEnv";
 import { useInjectDecoratorScript } from "./features/dektoratøren/useInjectDecoratorScript";
 import { NotFound } from "./features/feilhåndtering/404";
 import { InternalServerError } from "./features/feilhåndtering/500";
@@ -171,14 +173,20 @@ export default function App() {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  let content: React.ReactNode;
+  useEffect(() => {
+    injectDecoratorClientSide({
+      env: publicEnv.ENVIRONMENT,
+    });
+  }, []);
+
+  let innhold: React.ReactNode;
 
   if (isRouteErrorResponse(error)) {
-    content = <NotFound />;
+    innhold = <NotFound />;
   } else if (import.meta.env.DEV && error && error instanceof Error) {
-    content = <InternalServerError stack={error.stack} />;
+    innhold = <InternalServerError stack={error.stack} />;
   } else {
-    content = <InternalServerError />;
+    innhold = <InternalServerError />;
   }
 
   return (
@@ -189,9 +197,19 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
         <Meta />
         <Links />
       </head>
-      {content}
-      <ScrollRestoration />
-      <Scripts />
+      <body>
+        <Page.Block
+          className="flex-1"
+          as="main"
+          id="maincontent"
+          width="xl"
+          gutters
+        >
+          {innhold}
+        </Page.Block>
+        <ScrollRestoration />
+        <Scripts />
+      </body>
     </html>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,21 @@
 import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { reactRouterDevTools } from "react-router-devtools";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig({
-  plugins: [
-    tailwindcss(),
-    reactRouterDevTools(),
-    reactRouter(),
-    tsconfigPaths(),
-  ],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    plugins: [
+      tailwindcss(),
+      reactRouterDevTools(),
+      reactRouter(),
+      tsconfigPaths(),
+    ],
+    define: {
+      "import.meta.env.UMAMI_WEBSITE_ID": JSON.stringify(env.UMAMI_WEBSITE_ID),
+      "import.meta.env.ENVIRONMENT": JSON.stringify(env.ENVIRONMENT),
+    },
+  };
 });


### PR DESCRIPTION
Denne PRen reimplementerer feilsidene våre – både for 404 og 500-feil. Vi har ikke tilgang til språk eller dekoratøren, så vi får ikke hardkodet inn noen header eller footer. Skal sjekke med Dekoratøren-teamet om hvordan det kan gjøres, men enn så lenge er dette bedre enn "Internal Server Error" og masse støy i loggene.

<img width="1079" alt="image" src="https://github.com/user-attachments/assets/6ef318c7-e11c-44f3-bf5a-1575923c4a90" />
