### PR TITLE
Fiks feilsider part 2

### DIFF
--- a/app/config/env.server.ts
+++ b/app/config/env.server.ts
@@ -7,7 +7,9 @@ const envSchema = z.object({
     .string()
     .describe("ID for umami (sporingsverktøyet vårt)"),
   INGRESS: z.string().url().describe("Hvilken URL tjenesten kjører på"),
-  BIDRAG_BIDRAGSKALKULATOR_TOKEN: z.string().describe("Token for å kalle bidragskalkulator apiene"),
+  BIDRAG_BIDRAGSKALKULATOR_TOKEN: z
+    .string()
+    .describe("Token for å kalle bidragskalkulator APIene"),
 });
 
 const envParse = envSchema.safeParse(process.env);
@@ -17,7 +19,9 @@ if (!envParse.success) {
     "❌ Manglende eller ugyldige miljøvariabler:",
     envParse.error.format()
   );
-  throw new Error("Ugyldige miljøvariabler");
+  throw new Error(
+    "Ugyldige miljøvariabler: " + envParse.error.format().toString()
+  );
 }
 
 export const env = envParse.data;

--- a/app/config/publicEnv.ts
+++ b/app/config/publicEnv.ts
@@ -1,5 +1,23 @@
+import { z } from "zod";
+
 const isServer = typeof process !== "undefined";
 const miljøvariabler = isServer ? process.env : import.meta.env;
+
+const envSchema = z.object({
+  UMAMI_WEBSITE_ID: z.string(),
+  ENVIRONMENT: z.enum(["dev", "prod"]),
+});
+
+const parsedEnv = envSchema.safeParse(miljøvariabler);
+if (!parsedEnv.success) {
+  console.error(
+    "Ugyldige miljøvariabler definert i Vite-configen",
+    parsedEnv.error
+  );
+  throw new Error(
+    "Ugyldige miljøvariabler: " + parsedEnv.error.format().toString()
+  );
+}
 
 /**
  * Offentlig tilgjengelige miljøvariabler.
@@ -7,6 +25,6 @@ const miljøvariabler = isServer ? process.env : import.meta.env;
  * Disse er tilgjengelige på klientsiden, og skal ikke inneholde sensitiv informasjon.
  */
 export const publicEnv = {
-  UMAMI_WEBSITE_ID: miljøvariabler.UMAMI_WEBSITE_ID,
-  ENVIRONMENT: miljøvariabler.ENVIRONMENT,
+  UMAMI_WEBSITE_ID: parsedEnv.data.UMAMI_WEBSITE_ID,
+  ENVIRONMENT: parsedEnv.data.ENVIRONMENT,
 };

--- a/app/features/feilhåndtering/404.tsx
+++ b/app/features/feilhåndtering/404.tsx
@@ -8,47 +8,68 @@ import {
   List,
   VStack,
 } from "@navikt/ds-react";
+import { definerTekster, useOversettelse } from "~/utils/i18n";
 
 export function NotFound() {
+  const { t } = useOversettelse();
   return (
     <Box paddingBlock="20 16" data-aksel-template="404-v2">
-      <VStack gap="16">
-        <VStack gap="12" align="start">
-          <div>
-            <Heading level="1" size="large" spacing>
-              Beklager, vi fant ikke siden
-            </Heading>
-            <BodyShort>
-              Denne siden kan være slettet eller flyttet, eller det er en feil i
-              lenken.
-            </BodyShort>
-            <List>
-              <List.Item>Bruk gjerne søket eller menyen</List.Item>
-              <List.Item>
-                <Link href="https://www.nav.no">Gå til forsiden</Link>
-              </List.Item>
-            </List>
-          </div>
-          <Button as="a" href="https://barnebidragskalkulator.nav.no">
-            Gå til barnebidragskalkulatoren
-          </Button>
-          <Link href="https://www.nav.no/person/kontakt-oss/tilbakemeldinger/feil-og-mangler">
-            <BugIcon aria-hidden />
-            Meld gjerne fra om at lenken ikke virker
-          </Link>
-        </VStack>
-
+      <VStack gap="12" align="start">
         <div>
-          <Heading level="2" size="large" spacing>
-            Page not found
+          <Heading level="1" size="large" spacing>
+            {t(tekster.tittel)}
           </Heading>
-          <BodyShort spacing>The page you requested cannot be found.</BodyShort>
-          <BodyShort>
-            Go to the <Link href="https://www.nav.no">front page</Link>, or use
-            one of the links in the menu.
-          </BodyShort>
+          <BodyShort>{t(tekster.årsaker)}</BodyShort>
+          <List>
+            <List.Item>{t(tekster.forslag.brukSøkEllerMeny)}</List.Item>
+            <List.Item>{t(tekster.forslag.gåTilForsiden)}</List.Item>
+          </List>
         </div>
+        <Button as="a" href="https://barnebidragskalkulator.nav.no">
+          {t(tekster.ctas.gåTilKalkulator)}
+        </Button>
+        <Link href="https://www.nav.no/person/kontakt-oss/tilbakemeldinger/feil-og-mangler">
+          <BugIcon aria-hidden />
+          {t(tekster.ctas.meldFra)}
+        </Link>
       </VStack>
     </Box>
   );
 }
+
+const tekster = definerTekster({
+  tittel: {
+    nb: "Beklager, vi fant ikke siden",
+    en: "Sorry, we couldn't find the page",
+    nn: "Beklager, vi fant ikke siden",
+  },
+  årsaker: {
+    nb: "Denne siden kan være slettet eller flyttet, eller det er en feil i lenken.",
+    en: "This page may have been deleted or moved, or there is an error in the link.",
+    nn: "Denne siden kan være slettet eller flyttet, eller det er en feil i lenken.",
+  },
+  forslag: {
+    brukSøkEllerMeny: {
+      nb: "Bruk gjerne søket eller menyen",
+      en: "Please use the search or menu",
+      nn: "Bruk gjerne søket eller menyen",
+    },
+    gåTilForsiden: {
+      nb: <Link href="https://www.nav.no">Gå til forsiden</Link>,
+      en: <Link href="https://www.nav.no/en">Go to the front page</Link>,
+      nn: <Link href="https://www.nav.no">Gå til forsiden</Link>,
+    },
+  },
+  ctas: {
+    gåTilKalkulator: {
+      nb: "Gå til barnebidragskalkulatoren",
+      en: "Go to the child benefit calculator",
+      nn: "Gå til barnebidragskalkulatoren",
+    },
+    meldFra: {
+      nb: "Meld gjerne fra om at lenken ikke virker",
+      en: "Please report if the link is not working",
+      nn: "Meld gjerne fra om at lenken ikke virker",
+    },
+  },
+});

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,7 +5,6 @@ import {
 import parse from "html-react-parser";
 import {
   data,
-  isRouteErrorResponse,
   Links,
   Meta,
   Outlet,
@@ -28,7 +27,6 @@ import "./app.css";
 import { env } from "./config/env.server";
 import { publicEnv } from "./config/publicEnv";
 import { useInjectDecoratorScript } from "./features/dektoratøren/useInjectDecoratorScript";
-import { NotFound } from "./features/feilhåndtering/404";
 import { InternalServerError } from "./features/feilhåndtering/500";
 import { Analytics } from "./utils/analytics";
 import {
@@ -181,9 +179,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
 
   let innhold: React.ReactNode;
 
-  if (isRouteErrorResponse(error)) {
-    innhold = <NotFound />;
-  } else if (import.meta.env.DEV && error && error instanceof Error) {
+  if (import.meta.env.DEV && error && error instanceof Error) {
     innhold = <InternalServerError stack={error.stack} />;
   } else {
     innhold = <InternalServerError />;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -6,4 +6,7 @@ export default [
   route("/api/internal/isalive", "routes/api/internal/isalive.ts"),
   route("/api/internal/isready", "routes/api/internal/isready.ts"),
   route("/.well-known/security.txt", "routes/well-known/security.txt.ts"),
+
+  // Catch-all route for 404-feil
+  route("*", "routes/404.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/404.tsx
+++ b/app/routes/404.tsx
@@ -1,0 +1,5 @@
+import { NotFound } from "../features/feilhåndtering/404";
+
+export default function NotFoundRoute() {
+  return <NotFound />;
+}

--- a/app/routes/404.tsx
+++ b/app/routes/404.tsx
@@ -1,4 +1,9 @@
+import { data } from "react-router";
 import { NotFound } from "../features/feilhåndtering/404";
+
+export const loader = () => {
+  return data({}, { status: 404 });
+};
 
 export default function NotFoundRoute() {
   return <NotFound />;


### PR DESCRIPTION
Denne PRen adresserer et par ting:

- 404-sider får nå sin egen "catch-all route" som rendres når man ikke matcher en route. Dette gjør at root loaderen trigger, som gjør at dekoratøren rendres på riktig vis, og at vi kan oversette tekstene igjen.
- Bedre håndtering av miljøvariabler, inkludert parsing med zod og bedre feilmeldinger om noe mangler.

500-feil vil fortsatt se litt glitchy ut, men det får vi ikke gjort noe med såvidt jeg kan se.