### PR TITLE
Lag et nytt inputfelt for fødselsnumre

### DIFF
--- a/app/features/skjema/FormattertTallTextField.tsx
+++ b/app/features/skjema/FormattertTallTextField.tsx
@@ -32,8 +32,6 @@ export const FormattertTallTextField = (
   );
 };
 
-FormattertTallTextField.displayName = "FormattertTallTextField";
-
 const formatterTall = (verdi: string | number | undefined): string => {
   if (!verdi) return "";
 

--- a/app/features/skjema/FormattertTallTextField.tsx
+++ b/app/features/skjema/FormattertTallTextField.tsx
@@ -1,5 +1,6 @@
-import { TextField, type TextFieldProps } from "@navikt/ds-react";
-import { type ChangeEvent, type Ref } from "react";
+import { type TextFieldProps } from "@navikt/ds-react";
+import { type Ref } from "react";
+import { InternalFormatterbartTextField } from "./InternalFormatterbartTextField";
 
 export type FormattertTallTextFieldProps = Omit<TextFieldProps, "onChange"> & {
   onChange: (value: string) => void;
@@ -7,7 +8,7 @@ export type FormattertTallTextFieldProps = Omit<TextFieldProps, "onChange"> & {
 };
 
 /**
- * FormattertTallTextField er en komponent som formaterer et tall med tusenvis
+ * FormattertTallTextField er en komponent som formaterer et tall med mellomrom som tusenskilletegn
  * og komma som desimaltegn. onChange-callbacken blir kalt med den uformatterte verdien.
  *
  * Ellers fungerer det som et vanlig TextField.
@@ -19,26 +20,14 @@ export type FormattertTallTextFieldProps = Omit<TextFieldProps, "onChange"> & {
  * />
  * ```
  */
-export const FormattertTallTextField = ({
-  onChange,
-  value,
-  ...rest
-}: FormattertTallTextFieldProps) => {
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const formattertVerdi = formatterTall(e.target.value);
-    const uformattertVerdi = avformatterTall(formattertVerdi);
-
-    e.target.value = formattertVerdi;
-    onChange(uformattertVerdi);
-  };
-
+export const FormattertTallTextField = (
+  props: FormattertTallTextFieldProps,
+) => {
   return (
-    <TextField
-      type="text"
-      value={formatterTall(value)}
-      onChange={handleChange}
-      inputMode="numeric"
-      {...rest}
+    <InternalFormatterbartTextField
+      {...props}
+      formatterer={formatterTall}
+      avformatterer={avformatterTall}
     />
   );
 };

--- a/app/features/skjema/FødselsnummerTextField.tsx
+++ b/app/features/skjema/FødselsnummerTextField.tsx
@@ -30,8 +30,6 @@ export const FødselsnummerTextField = (props: FødselsnummerTextFieldProps) => 
   );
 };
 
-FødselsnummerTextField.displayName = "FødselsnummerTextField";
-
 const formatterTall = (verdi: string | number | undefined): string => {
   if (!verdi) return "";
 

--- a/app/features/skjema/FødselsnummerTextField.tsx
+++ b/app/features/skjema/FødselsnummerTextField.tsx
@@ -1,0 +1,53 @@
+import { type TextFieldProps } from "@navikt/ds-react";
+import { type Ref } from "react";
+import { InternalFormatterbartTextField } from "./InternalFormatterbartTextField";
+
+export type FødselsnummerTextFieldProps = Omit<TextFieldProps, "onChange"> & {
+  onChange: (value: string) => void;
+  ref?: Ref<HTMLInputElement | null>;
+};
+
+/**
+ * FødselsnummerTextField er en komponent som formaterer et tall som fødselsnummer.
+ * onChange-callbacken blir kalt med den uformatterte verdien.
+ *
+ * Ellers fungerer det som et vanlig TextField.
+ *
+ * ```tsx
+ * <FødselsnummerTextField
+ *   {...form.field("deg.fødselsnummer").getControlProps()}
+ *   label="Hva er fødselsnummeret ditt?"
+ * />
+ * ```
+ */
+export const FødselsnummerTextField = (props: FødselsnummerTextFieldProps) => {
+  return (
+    <InternalFormatterbartTextField
+      {...props}
+      formatterer={formatterTall}
+      avformatterer={avformatterTall}
+    />
+  );
+};
+
+FødselsnummerTextField.displayName = "FødselsnummerTextField";
+
+const formatterTall = (verdi: string | number | undefined): string => {
+  if (!verdi) return "";
+
+  const renVerdi = String(verdi).replace(/\D/g, "");
+
+  const begrensetVerdi = renVerdi.slice(0, 11);
+
+  if (begrensetVerdi.length <= 6) {
+    return begrensetVerdi;
+  } else {
+    const første6 = begrensetVerdi.slice(0, 6);
+    const siste5 = begrensetVerdi.slice(6);
+    return `${første6} ${siste5}`;
+  }
+};
+
+const avformatterTall = (verdi: string): string => {
+  return verdi.replace(/\s/g, "");
+};

--- a/app/features/skjema/FødselsnummerTextField.tsx
+++ b/app/features/skjema/FødselsnummerTextField.tsx
@@ -41,11 +41,10 @@ const formatterTall = (verdi: string | number | undefined): string => {
 
   if (begrensetVerdi.length <= 6) {
     return begrensetVerdi;
-  } else {
-    const første6 = begrensetVerdi.slice(0, 6);
-    const siste5 = begrensetVerdi.slice(6);
-    return `${første6} ${siste5}`;
   }
+  const dato = begrensetVerdi.slice(0, 6);
+  const personnummer = begrensetVerdi.slice(6);
+  return `${dato} ${personnummer}`;
 };
 
 const avformatterTall = (verdi: string): string => {

--- a/app/features/skjema/InternalFormatterbartTextField.tsx
+++ b/app/features/skjema/InternalFormatterbartTextField.tsx
@@ -45,11 +45,11 @@ export const InternalFormatterbartTextField = ({
 
   return (
     <TextField
+      {...rest}
       type="text"
       value={formatterer(value ? String(value) : "")}
       onChange={handleChange}
       inputMode="numeric"
-      {...rest}
     />
   );
 };

--- a/app/features/skjema/InternalFormatterbartTextField.tsx
+++ b/app/features/skjema/InternalFormatterbartTextField.tsx
@@ -38,8 +38,6 @@ export const InternalFormatterbartTextField = ({
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const formattertVerdi = formatterer(e.target.value);
     const uformattertVerdi = avformatterer(formattertVerdi);
-
-    e.target.value = formattertVerdi;
     onChange(uformattertVerdi);
   };
 

--- a/app/features/skjema/InternalFormatterbartTextField.tsx
+++ b/app/features/skjema/InternalFormatterbartTextField.tsx
@@ -12,7 +12,7 @@ export type InternalFormatterbartTextFieldProps = Omit<
 };
 
 /**
- * InternalFormatterbartTextField er en komponent som formaterer et tall med den gitte formatterer og avformatterer-funksjonen..
+ * InternalFormatterbartTextField er en komponent som formaterer et tall med den gitte formatterer og avformatterer-funksjonen.
  * onChange-callbacken blir kalt med den uformatterte verdien.
  *
  * Ellers fungerer det som et vanlig TextField.

--- a/app/features/skjema/InternalFormatterbartTextField.tsx
+++ b/app/features/skjema/InternalFormatterbartTextField.tsx
@@ -1,0 +1,57 @@
+import { TextField, type TextFieldProps } from "@navikt/ds-react";
+import { type ChangeEvent, type Ref } from "react";
+
+export type InternalFormatterbartTextFieldProps = Omit<
+  TextFieldProps,
+  "onChange"
+> & {
+  onChange: (value: string) => void;
+  ref?: Ref<HTMLInputElement | null>;
+  formatterer: (verdi: string) => string;
+  avformatterer: (verdi: string) => string;
+};
+
+/**
+ * InternalFormatterbartTextField er en komponent som formaterer et tall med den gitte formatterer og avformatterer-funksjonen..
+ * onChange-callbacken blir kalt med den uformatterte verdien.
+ *
+ * Ellers fungerer det som et vanlig TextField.
+ *
+ * @internal Skal kun brukes av interne komponenter som definerer formatteringsreglene
+ *
+ * ```tsx
+ * <InternalFormatterbartTextField
+ *   {...form.field("deg.fødselsnummer").getControlProps()}
+ *   label="Hva er fødselsnummeret ditt?"
+ *   formatterer={formatterTall}
+ *   avformatterer={avformatterTall}
+ * />
+ * ```
+ */
+export const InternalFormatterbartTextField = ({
+  onChange,
+  value,
+  formatterer,
+  avformatterer,
+  ...rest
+}: InternalFormatterbartTextFieldProps) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const formattertVerdi = formatterer(e.target.value);
+    const uformattertVerdi = avformatterer(formattertVerdi);
+
+    e.target.value = formattertVerdi;
+    onChange(uformattertVerdi);
+  };
+
+  return (
+    <TextField
+      type="text"
+      value={formatterer(value ? String(value) : "")}
+      onChange={handleChange}
+      inputMode="numeric"
+      {...rest}
+    />
+  );
+};
+
+InternalFormatterbartTextField.displayName = "InternalFormatterbartTextField";

--- a/app/features/skjema/InternalFormatterbartTextField.tsx
+++ b/app/features/skjema/InternalFormatterbartTextField.tsx
@@ -51,5 +51,3 @@ export const InternalFormatterbartTextField = ({
     />
   );
 };
-
-InternalFormatterbartTextField.displayName = "InternalFormatterbartTextField";


### PR DESCRIPTION
Denne PRen legger til et nytt inputfelt for fødsels- og D-numre, som setter inn et mellomrom for deg mellom dato og personnummer.

Siden mye av logikken er lik for dette feltet og FormattertTallTextField, dro jeg ut en intern komponent InternalFormatterbartTextField, som inneholder det som er felles for dem.