### PR TITLE
Endre valg for bosted

### DIFF
--- a/app/features/skjema/BostedOgSamvær.tsx
+++ b/app/features/skjema/BostedOgSamvær.tsx
@@ -1,16 +1,10 @@
-import { Radio, RadioGroup } from "@navikt/ds-react";
 import { useFieldArray, useFormContext } from "@rvf/react";
-import { Slider } from "~/components/ui/slider";
 import { definerTekster, useOversettelse } from "~/utils/i18n";
 import { FormattertTallTextField } from "./FormattertTallTextField";
 import { usePersoninformasjon } from "./personinformasjon/usePersoninformasjon";
-import type { FastBosted, InnloggetSkjema } from "./schema";
-import { finnBarnBasertPåIdent, SAMVÆR_STANDARDVERDI } from "./utils";
-
-const BOSTED_OPTIONS: FastBosted[] = [
-  "DELT_FAST_BOSTED",
-  "IKKE_DELT_FAST_BOSTED",
-];
+import { Samvær } from "./Samvær";
+import type { InnloggetSkjema } from "./schema";
+import { finnBarnBasertPåIdent } from "./utils";
 
 export const BostedOgSamvær = () => {
   const personinformasjon = usePersoninformasjon();
@@ -21,70 +15,20 @@ export const BostedOgSamvær = () => {
 
   return (
     <>
-      {barnArray.map((key, barnField) => {
+      {barnArray.map((key, barnField, index) => {
         const barnInfo = finnBarnBasertPåIdent(
           barnField.value("ident"),
           personinformasjon,
         );
 
-        const samvær = barnField.value("samvær") ?? SAMVÆR_STANDARDVERDI;
         const alder = barnInfo?.alder ?? "";
         const visSpørsmålOmBarnetilsynsutgift =
           alder !== "" && Number(alder) < 11;
 
-        const samværsgradBeskrivelse =
-          samvær === "1"
-            ? t(tekster.samvær.enNatt)
-            : t(tekster.samvær.netter(samvær));
-
-        const borHosEnForelder =
-          barnField.value("bosted") === "IKKE_DELT_FAST_BOSTED";
-
         return (
           <div key={key} className="border p-4 rounded-md space-y-4">
             <h3 className="font-bold text-xl">{`${barnInfo?.fulltNavn} (${barnInfo?.alder})`}</h3>
-            <RadioGroup
-              {...barnField.field("bosted").getInputProps()}
-              error={barnField.field("bosted").error()}
-              legend={t(tekster.bosted.label(`${barnInfo?.fornavn}`))}
-            >
-              {BOSTED_OPTIONS.map((bosted) => {
-                return (
-                  <Radio value={bosted} key={bosted}>
-                    {t(tekster.bosted.valg[bosted])}
-                  </Radio>
-                );
-              })}
-            </RadioGroup>
-
-            {borHosEnForelder && (
-              <Slider
-                {...barnField.field("samvær").getControlProps()}
-                label={t(tekster.samvær.label)}
-                description={t(tekster.samvær.beskrivelse)}
-                error={barnField.field("samvær").error()}
-                min={0}
-                max={30}
-                step={1}
-                list={[
-                  {
-                    label: t(tekster.samvær.beskrivelser.ingenNetterHosDeg),
-                    value: 0,
-                  },
-                  {
-                    label: t(
-                      tekster.samvær.beskrivelser.halvpartenAvTidenHosDeg,
-                    ),
-                    value: 15,
-                  },
-                  {
-                    label: t(tekster.samvær.beskrivelser.alleNetterHosDeg),
-                    value: 30,
-                  },
-                ]}
-                valueDescription={samværsgradBeskrivelse}
-              />
-            )}
+            <Samvær barnIndex={index} />
             {visSpørsmålOmBarnetilsynsutgift && (
               <FormattertTallTextField
                 {...barnField.field("barnetilsynsutgift").getControlProps()}

--- a/app/features/skjema/Samvær.tsx
+++ b/app/features/skjema/Samvær.tsx
@@ -42,7 +42,7 @@ export function Samvær({ barnIndex }: SamværProps) {
         })}
       </RadioGroup>
 
-      {borHosMeg ? (
+      {borHosMeg && (
         <Slider
           {...barnField.field("samvær").getControlProps()}
           label={t(tekster.samvær.label)}
@@ -63,7 +63,8 @@ export function Samvær({ barnIndex }: SamværProps) {
           ]}
           valueDescription={samværsgradBeskrivelse}
         />
-      ) : borHosMedforelder ? (
+      )}
+      {borHosMedforelder && (
         <Slider
           {...barnField.field("samvær").getControlProps()}
           label={t(tekster.samvær.label)}
@@ -84,7 +85,7 @@ export function Samvær({ barnIndex }: SamværProps) {
           ]}
           valueDescription={samværsgradBeskrivelse}
         />
-      ) : null}
+      )}
     </>
   );
 }

--- a/app/features/skjema/Samvær.tsx
+++ b/app/features/skjema/Samvær.tsx
@@ -1,0 +1,172 @@
+import { Radio, RadioGroup } from "@navikt/ds-react";
+import { useFormContext, useFormScope } from "@rvf/react";
+import { Slider } from "~/components/ui/slider";
+import { definerTekster, useOversettelse } from "~/utils/i18n";
+import type { FastBosted, ManueltSkjema } from "./schema";
+import { SAMVÆR_STANDARDVERDI } from "./utils";
+
+const BOSTED_VALG: FastBosted[] = [
+  "DELT_FAST_BOSTED",
+  "HOS_MEG",
+  "HOS_MEDFORELDER",
+];
+
+type SamværProps = {
+  barnIndex: number;
+};
+export function Samvær({ barnIndex }: SamværProps) {
+  const { t } = useOversettelse();
+  const form = useFormContext<ManueltSkjema>();
+  const barnField = useFormScope(form.scope(`barn[${barnIndex}]`));
+  const samvær = barnField.value("samvær") || SAMVÆR_STANDARDVERDI;
+  const samværsgradBeskrivelse =
+    samvær === "1"
+      ? t(tekster.samvær.enNatt)
+      : t(tekster.samvær.netter(samvær));
+
+  const bosted = barnField.value("bosted");
+  const borHosMeg = bosted === "HOS_MEG";
+  const borHosMedforelder = bosted === "HOS_MEDFORELDER";
+
+  return (
+    <>
+      <RadioGroup
+        {...barnField.getControlProps("bosted", {
+          onChange: () => {
+            barnField.field("samvær").setValue(SAMVÆR_STANDARDVERDI);
+          },
+        })}
+        error={barnField.field("bosted").error()}
+        legend={t(tekster.bosted.label)}
+      >
+        {BOSTED_VALG.map((bosted) => {
+          return (
+            <Radio value={bosted} key={bosted}>
+              {t(tekster.bosted.valg[bosted])}
+            </Radio>
+          );
+        })}
+      </RadioGroup>
+
+      {borHosMeg ? (
+        <Slider
+          {...barnField.field("samvær").getControlProps()}
+          label={t(tekster.samvær.label)}
+          description={t(tekster.samvær.beskrivelse)}
+          error={barnField.field("samvær").error()}
+          min={15}
+          max={30}
+          step={1}
+          list={[
+            {
+              label: t(tekster.samvær.beskrivelser.halvpartenAvTidenHosDeg),
+              value: 15,
+            },
+            {
+              label: t(tekster.samvær.beskrivelser.alleNetterHosDeg),
+              value: 30,
+            },
+          ]}
+          valueDescription={samværsgradBeskrivelse}
+        />
+      ) : borHosMedforelder ? (
+        <Slider
+          {...barnField.field("samvær").getControlProps()}
+          label={t(tekster.samvær.label)}
+          description={t(tekster.samvær.beskrivelse)}
+          error={barnField.field("samvær").error()}
+          min={0}
+          max={15}
+          step={1}
+          list={[
+            {
+              label: t(tekster.samvær.beskrivelser.ingenNetterHosDeg),
+              value: 0,
+            },
+            {
+              label: t(tekster.samvær.beskrivelser.halvpartenAvTidenHosDeg),
+              value: 15,
+            },
+          ]}
+          valueDescription={samværsgradBeskrivelse}
+        />
+      ) : null}
+    </>
+  );
+}
+
+const tekster = definerTekster({
+  bosted: {
+    label: {
+      nb: "Hvor skal barnet bo fast?",
+      en: "Where will the child have a permanent address?",
+      nn: "Kvar skal barnet bu fast?",
+    },
+    valg: {
+      velg: {
+        nb: "Velg hvor barnet skal bo",
+        en: "Select where the child will live",
+        nn: "Velg kvar barnet skal bu",
+      },
+      DELT_FAST_BOSTED: {
+        nb: "Vi har avtale om fast bosted hos begge (delt fast bosted)",
+        en: "We have an agreement on permanent residence with both of us (shared permanent residence)",
+        nn: "Vi har avtale om fast bustad hos begge (delt fast bustad)",
+      },
+      HOS_MEG: {
+        nb: "Barnet bor fast hos meg, og har samvær med den andre",
+        en: "The child lives with me and has visitation with the other parent",
+        nn: "Barnet bur fast hos meg, og har samvær med den andre",
+      },
+      HOS_MEDFORELDER: {
+        nb: "Barnet bor fast hos medforelder, og har samvær med meg",
+        en: "The child lives with the co-parent and has visitation with me",
+        nn: "Barnet bur fast hos medforelder, og har samvær med meg",
+      },
+      hosDenAndre: (navn) => ({
+        nb: `Barnet bor hos ${navn}`,
+        en: `The child lives with ${navn}`,
+        nn: `Barnet bur hos ${navn}`,
+      }),
+    },
+  },
+  samvær: {
+    label: {
+      nb: "Hvor mye vil barnet være sammen med deg?",
+      en: "How much will the child stay with you?",
+      nn: "Kor mykje vil barnet vere saman med deg?",
+    },
+    beskrivelse: {
+      nb: "Estimer hvor mange netter barnet vil være hos deg i snitt per måned",
+      en: "Estimate how many nights the child will stay with you on average per month",
+      nn: "Estimer kor mange netter barnet vil vere hos deg i snitt per månad",
+    },
+    netter: (antall) => ({
+      nb: `${antall} netter hos deg`,
+      en: `${antall} nights with you`,
+      nn: `${antall} netter hos deg`,
+    }),
+    enNatt: {
+      nb: "1 natt hos deg",
+      en: "1 night with you",
+      nn: "1 natt hos deg",
+    },
+    beskrivelser: {
+      ingenNetterHosDeg: {
+        nb: "Ingen netter hos deg",
+        en: "No nights with you",
+        nn: "Ingen netter hos deg",
+      },
+      halvpartenAvTidenHosDeg: {
+        nb: "Halvparten av nettene hos deg",
+        en: "Half the nights with you",
+        nn: "Halvparten av nettene hos deg",
+      },
+      alleNetterHosDeg: {
+        nb: "Alle netter hos deg",
+        en: "All the nights with you",
+        nn: "Alle netter hos deg",
+      },
+    },
+  },
+});

--- a/app/features/skjema/Samvær.tsx
+++ b/app/features/skjema/Samvær.tsx
@@ -2,14 +2,8 @@ import { Radio, RadioGroup } from "@navikt/ds-react";
 import { useFormContext, useFormScope } from "@rvf/react";
 import { Slider } from "~/components/ui/slider";
 import { definerTekster, useOversettelse } from "~/utils/i18n";
-import type { FastBosted, ManueltSkjema } from "./schema";
+import { FastBosted, type ManueltSkjema } from "./schema";
 import { SAMVÆR_STANDARDVERDI } from "./utils";
-
-const BOSTED_VALG: FastBosted[] = [
-  "DELT_FAST_BOSTED",
-  "HOS_MEG",
-  "HOS_MEDFORELDER",
-];
 
 type SamværProps = {
   barnIndex: number;
@@ -39,7 +33,7 @@ export function Samvær({ barnIndex }: SamværProps) {
         error={barnField.field("bosted").error()}
         legend={t(tekster.bosted.label)}
       >
-        {BOSTED_VALG.map((bosted) => {
+        {FastBosted.options.map((bosted) => {
           return (
             <Radio value={bosted} key={bosted}>
               {t(tekster.bosted.valg[bosted])}

--- a/app/features/skjema/Samvær.tsx
+++ b/app/features/skjema/Samvær.tsx
@@ -108,9 +108,9 @@ const tekster = definerTekster({
         nn: "Vi har avtale om fast bustad hos begge (delt fast bustad)",
       },
       HOS_MEG: {
-        nb: "Barnet bor fast hos meg, og har samvær med den andre",
-        en: "The child lives with me and has visitation with the other parent",
-        nn: "Barnet bur fast hos meg, og har samvær med den andre",
+        nb: "Barnet bor fast hos meg, og har samvær med medforelderen",
+        en: "The child lives with me and has visitation with the other co-parent",
+        nn: "Barnet bur fast hos meg, og har samvær med medforelderen",
       },
       HOS_MEDFORELDER: {
         nb: "Barnet bor fast hos medforelder, og har samvær med meg",

--- a/app/features/skjema/beregning/api.server.ts
+++ b/app/features/skjema/beregning/api.server.ts
@@ -147,7 +147,6 @@ export const hentBidragsutregning = async (token: string, request: Request) => {
       const samværsklasse = kalkulerSamværsklasse(barn.samvær, barn.bosted);
       const bidragstype = kalkulerBidragstype(
         barn.bosted,
-        barn.samvær,
         inntektForelder1,
         inntektForelder2,
       );
@@ -194,7 +193,6 @@ export const hentManuellBidragsutregning = async (request: Request) => {
       const samværsklasse = kalkulerSamværsklasse(barn.samvær, barn.bosted);
       const bidragstype = kalkulerBidragstype(
         barn.bosted,
-        barn.samvær,
         inntektForelder1,
         inntektForelder2,
       );

--- a/app/features/skjema/manuell/EnkeltbarnSkjema.tsx
+++ b/app/features/skjema/manuell/EnkeltbarnSkjema.tsx
@@ -16,8 +16,7 @@ type Props = {
 };
 
 export const EnkeltbarnSkjema = ({ barnIndex, onFjernBarn }: Props) => {
-  const [fremhevUnderholdskostnad, settFremhevUnderholdskostnad] =
-    useState(false);
+  const [erAlderSatt, setAlderSatt] = useState(false);
   const { underholdskostnader } = usePersoninformasjon();
   const { t } = useOversettelse();
   const form = useFormContext<ManueltSkjema>();
@@ -25,16 +24,16 @@ export const EnkeltbarnSkjema = ({ barnIndex, onFjernBarn }: Props) => {
   const barnField = useFormScope(form.scope(`barn[${barnIndex}]`));
 
   const alder = barnField.value("alder");
-  const visSpørsmålOmBarnetilsynsutgift = alder !== "" && Number(alder) < 11;
+  const visSpørsmålOmBarnetilsynsutgift = erAlderSatt && Number(alder) < 11;
 
   const overskrift = t(tekster.overskrift.barn(barnIndex + 1));
 
-  const handleChangeAlder = () => settFremhevUnderholdskostnad(false);
+  const handleChangeAlder = () => setAlderSatt(false);
 
   const handleBlurAlder = (event: React.FocusEvent<HTMLInputElement>) => {
     const alder = event.target.value;
     if (!!alder) {
-      settFremhevUnderholdskostnad(true);
+      setAlderSatt(true);
     }
   };
 
@@ -70,7 +69,7 @@ export const EnkeltbarnSkjema = ({ barnIndex, onFjernBarn }: Props) => {
           {underholdskostnadsgrupper.map(
             ({ label, underholdskostnad, aldre }) => {
               const fremhevGruppe =
-                fremhevUnderholdskostnad && aldre.includes(Number(alder));
+                erAlderSatt && aldre.includes(Number(alder));
               return (
                 <li key={label}>
                   <span

--- a/app/features/skjema/manuell/EnkeltbarnSkjema.tsx
+++ b/app/features/skjema/manuell/EnkeltbarnSkjema.tsx
@@ -1,29 +1,14 @@
 import { PersonCrossIcon } from "@navikt/aksel-icons";
-import {
-  BodyLong,
-  Button,
-  Radio,
-  RadioGroup,
-  ReadMore,
-  TextField,
-} from "@navikt/ds-react";
+import { BodyLong, Button, ReadMore, TextField } from "@navikt/ds-react";
 import { useFormContext, useFormScope } from "@rvf/react";
 import { useMemo, useState } from "react";
-import { Slider } from "~/components/ui/slider";
 import { definerTekster, useOversettelse } from "~/utils/i18n";
 import { formatterSum } from "~/utils/tall";
 import { FormattertTallTextField } from "../FormattertTallTextField";
 import { usePersoninformasjon } from "../personinformasjon/usePersoninformasjon";
-import type { FastBosted, ManueltSkjema } from "../schema";
-import {
-  SAMVÆR_STANDARDVERDI,
-  tilUnderholdskostnadsgruppeMedLabel,
-} from "../utils";
-
-const BOSTED_OPTIONS: FastBosted[] = [
-  "DELT_FAST_BOSTED",
-  "IKKE_DELT_FAST_BOSTED",
-];
+import { Samvær } from "../Samvær";
+import type { ManueltSkjema } from "../schema";
+import { tilUnderholdskostnadsgruppeMedLabel } from "../utils";
 
 type Props = {
   barnIndex: number;
@@ -40,16 +25,7 @@ export const EnkeltbarnSkjema = ({ barnIndex, onFjernBarn }: Props) => {
   const barnField = useFormScope(form.scope(`barn[${barnIndex}]`));
 
   const alder = barnField.value("alder");
-  const samvær = barnField.value("samvær") ?? SAMVÆR_STANDARDVERDI;
   const visSpørsmålOmBarnetilsynsutgift = alder !== "" && Number(alder) < 11;
-
-  const samværsgradBeskrivelse =
-    samvær === "1"
-      ? t(tekster.samvær.enNatt)
-      : t(tekster.samvær.netter(samvær));
-
-  const borHosEnForelder =
-    barnField.value("bosted") === "IKKE_DELT_FAST_BOSTED";
 
   const overskrift = t(tekster.overskrift.barn(barnIndex + 1));
 
@@ -107,46 +83,8 @@ export const EnkeltbarnSkjema = ({ barnIndex, onFjernBarn }: Props) => {
         </ul>
       </ReadMore>
 
-      <RadioGroup
-        {...barnField.field("bosted").getInputProps()}
-        error={barnField.field("bosted").error()}
-        legend={t(tekster.bosted.label)}
-      >
-        {BOSTED_OPTIONS.map((bosted) => {
-          return (
-            <Radio value={bosted} key={bosted}>
-              {t(tekster.bosted.valg[bosted])}
-            </Radio>
-          );
-        })}
-      </RadioGroup>
+      <Samvær barnIndex={barnIndex} />
 
-      {borHosEnForelder && (
-        <Slider
-          {...barnField.field("samvær").getControlProps()}
-          label={t(tekster.samvær.label)}
-          description={t(tekster.samvær.beskrivelse)}
-          error={barnField.field("samvær").error()}
-          min={0}
-          max={30}
-          step={1}
-          list={[
-            {
-              label: t(tekster.samvær.beskrivelser.ingenNetterHosDeg),
-              value: 0,
-            },
-            {
-              label: t(tekster.samvær.beskrivelser.halvpartenAvTidenHosDeg),
-              value: 15,
-            },
-            {
-              label: t(tekster.samvær.beskrivelser.alleNetterHosDeg),
-              value: 30,
-            },
-          ]}
-          valueDescription={samværsgradBeskrivelse}
-        />
-      )}
       {visSpørsmålOmBarnetilsynsutgift && (
         <FormattertTallTextField
           {...barnField.field("barnetilsynsutgift").getControlProps()}
@@ -195,74 +133,6 @@ const tekster = definerTekster({
         nb: "Det viktigste grunnlaget for beregningen er hva et barn koster – også kjent som underholdskostnader. Disse summene hentes fra SIFOs referansebudsjetter, og oppdateres hvert år. Underholdskostnaden for barn i ulike aldre er i dag:",
         en: "The most important basis for the calculation is what a child costs – also known as child support costs. These amounts are taken from SIFOs reference budgets and are updated annually. The maintenance cost for children of different ages is currently:",
         nn: "Det viktigaste grunnlaget for berekninga er kva eit barn kostar – også kjent som underhaldskostnader. Desse summane hentar vi frå SIFOs referansebudsjett, og oppdaterer kvart år. Underhaldskostnaden for barn i ulike aldrar er i dag:",
-      },
-    },
-  },
-  bosted: {
-    label: {
-      nb: "Hvor skal barnet bo fast?",
-      en: "Where will the child have a permanent address?",
-      nn: "Kvar skal barnet bu fast?",
-    },
-    valg: {
-      velg: {
-        nb: "Velg hvor barnet skal bo",
-        en: "Select where the child will live",
-        nn: "Velg kvar barnet skal bu",
-      },
-      DELT_FAST_BOSTED: {
-        nb: "Vi har avtale om fast bosted hos begge (delt fast bosted)",
-        en: "We have an agreement on permanent residence with both of us (shared permanent residence)",
-        nn: "Vi har avtale om fast bustad hos begge (delt fast bustad)",
-      },
-      IKKE_DELT_FAST_BOSTED: {
-        nb: "Vi har avtale om fast bosted hos én og samvær med den andre",
-        en: "We have an agreement on permanent residence with one and visitation with the other",
-        nn: "Vi har avtale om fast bustad hos éin og samvær med den andre",
-      },
-      hosDenAndre: (navn) => ({
-        nb: `Barnet bor hos ${navn}`,
-        en: `The child lives with ${navn}`,
-        nn: `Barnet bur hos ${navn}`,
-      }),
-    },
-  },
-  samvær: {
-    label: {
-      nb: "Hvor mye vil barnet være sammen med deg?",
-      en: "How much will the child stay with you?",
-      nn: "Kor mykje vil barnet vere saman med deg?",
-    },
-    beskrivelse: {
-      nb: "Estimer hvor mange netter barnet vil være hos deg i snitt per måned",
-      en: "Estimate how many nights the child will stay with you on average per month",
-      nn: "Estimer kor mange netter barnet vil vere hos deg i snitt per månad",
-    },
-    netter: (antall) => ({
-      nb: `${antall} netter hos deg`,
-      en: `${antall} nights with you`,
-      nn: `${antall} netter hos deg`,
-    }),
-    enNatt: {
-      nb: "1 natt hos deg",
-      en: "1 night with you",
-      nn: "1 natt hos deg",
-    },
-    beskrivelser: {
-      ingenNetterHosDeg: {
-        nb: "Ingen netter hos deg",
-        en: "No nights with you",
-        nn: "Ingen netter hos deg",
-      },
-      halvpartenAvTidenHosDeg: {
-        nb: "Halvparten av nettene hos deg",
-        en: "Half the nights with you",
-        nn: "Halvparten av nettene hos deg",
-      },
-      alleNetterHosDeg: {
-        nb: "Alle netter hos deg",
-        en: "All the nights with you",
-        nn: "Alle netter hos deg",
       },
     },
   },

--- a/app/features/skjema/schema.ts
+++ b/app/features/skjema/schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { definerTekster, oversett, Språk } from "~/utils/i18n";
 
-const fastBosted = z.enum(["DELT_FAST_BOSTED", "IKKE_DELT_FAST_BOSTED"]);
+const fastBosted = z.enum(["DELT_FAST_BOSTED", "HOS_MEG", "HOS_MEDFORELDER"]);
 
 export const InnloggetBarnSkjemaSchema = z.object({
   ident: z.string().length(11),

--- a/app/features/skjema/schema.ts
+++ b/app/features/skjema/schema.ts
@@ -1,11 +1,15 @@
 import { z } from "zod";
 import { definerTekster, oversett, Språk } from "~/utils/i18n";
 
-const fastBosted = z.enum(["DELT_FAST_BOSTED", "HOS_MEG", "HOS_MEDFORELDER"]);
+export const FastBosted = z.enum([
+  "DELT_FAST_BOSTED",
+  "HOS_MEG",
+  "HOS_MEDFORELDER",
+]);
 
 export const InnloggetBarnSkjemaSchema = z.object({
   ident: z.string().length(11),
-  bosted: z.enum([...fastBosted.options, ""]),
+  bosted: z.enum([...FastBosted.options, ""]),
   samvær: z.string(),
   barnetilsynsutgift: z.string(),
 });
@@ -29,7 +33,7 @@ export const InnloggetSkjemaSchema = z.object({
 
 export const ManueltBarnSkjemaSchema = z.object({
   alder: z.string(),
-  bosted: z.enum([...fastBosted.options, ""]),
+  bosted: z.enum([...FastBosted.options, ""]),
   samvær: z.string(),
   barnetilsynsutgift: z.string(),
 });
@@ -55,7 +59,7 @@ export const lagInnloggetBarnSkjema = (språk: Språk) => {
     ident: z
       .string()
       .length(11, oversett(språk, tekster.feilmeldinger.barnIdent.ugyldig)),
-    bosted: z.enum(fastBosted.options, {
+    bosted: z.enum(FastBosted.options, {
       message: oversett(språk, tekster.feilmeldinger.bostatus.påkrevd),
     }),
     samvær: z
@@ -176,7 +180,7 @@ export const lagManueltBarnSkjema = (språk: Språk) => {
           .max(25, oversett(språk, tekster.feilmeldinger.barn.alder.maksimum))
           .int(oversett(språk, tekster.feilmeldinger.barn.alder.heltall)),
       ),
-    bosted: z.enum(fastBosted.options, {
+    bosted: z.enum(FastBosted.options, {
       message: oversett(språk, tekster.feilmeldinger.bostatus.påkrevd),
     }),
     samvær: z
@@ -225,7 +229,6 @@ export const lagManueltSkjema = (språk: Språk) => {
   });
 };
 
-export type FastBosted = z.infer<typeof fastBosted>;
 export type InnloggetBarnSkjema = z.infer<typeof InnloggetBarnSkjemaSchema>;
 export type InnloggetSkjema = z.infer<typeof InnloggetSkjemaSchema>;
 export type InnloggetSkjemaValidert = z.infer<

--- a/app/features/skjema/utils.ts
+++ b/app/features/skjema/utils.ts
@@ -184,14 +184,13 @@ export function kalkulerSamværsklasse(
  */
 export function kalkulerBidragstype(
   bostatus: FastBosted,
-  samvær: number,
   inntektForelder1: number,
   inntektForelder2: number,
 ): "MOTTAKER" | "PLIKTIG" {
   if (bostatus === "DELT_FAST_BOSTED") {
     return inntektForelder1 > inntektForelder2 ? "PLIKTIG" : "MOTTAKER";
   }
-  return samvær >= 15 ? "MOTTAKER" : "PLIKTIG";
+  return bostatus === "HOS_MEG" ? "MOTTAKER" : "PLIKTIG";
 }
 
 export const finnBarnBasertPåIdent = (

--- a/app/features/skjema/utils.ts
+++ b/app/features/skjema/utils.ts
@@ -1,3 +1,4 @@
+import type z from "zod";
 import type { Samværsklasse } from "./beregning/schema";
 import type {
   Barn,
@@ -159,7 +160,7 @@ export const hentManueltSkjemaStandardverdi = (
  */
 export function kalkulerSamværsklasse(
   samværsgrad: number,
-  bostatus: FastBosted,
+  bostatus: z.infer<typeof FastBosted>,
 ): Samværsklasse {
   if (bostatus === "DELT_FAST_BOSTED") {
     return "DELT_BOSTED";
@@ -183,7 +184,7 @@ export function kalkulerSamværsklasse(
  * Avgjør om forelderen er mottaker eller pliktig basert på samværsgrad
  */
 export function kalkulerBidragstype(
-  bostatus: FastBosted,
+  bostatus: z.infer<typeof FastBosted>,
   inntektForelder1: number,
   inntektForelder2: number,
 ): "MOTTAKER" | "PLIKTIG" {


### PR DESCRIPTION
Denne PRen endrer hvordan man velger bosted. Istedenfor å si om man har avtale om delt bosted eller ei, velger man om man har delt bosted, om man bor hos deg eller hos den andre forelderen. 

Brukte også anledningen til å refaktorere ut bosted og samvær som sin egen komponent, siden den er lik for begge flytene våre.

![demo](https://github.com/user-attachments/assets/5a9c5012-f54f-45ae-8f18-5d9c53301772)
