### PR TITLE
Vise utregning for ett barn i resultatpanel

### DIFF
--- a/app/features/skjema/manuell/ManueltResultatpanel.tsx
+++ b/app/features/skjema/manuell/ManueltResultatpanel.tsx
@@ -111,32 +111,16 @@ export const ManueltResultatpanel = ({
             </ExpansionCardTitle>
           </ExpansionCardHeader>
           <ExpansionCardContent>
-            {data.resultater.length > 1 && (
-              <>
-                <BodyLong spacing>
-                  {t(tekster.detaljer.utregningPerBarn)}
-                </BodyLong>
-                <List>
-                  {data.resultater.map((resultat, index) => (
-                    <ListItem key={index}>
-                      {resultat.bidragstype === "MOTTAKER"
-                        ? t(
-                            tekster.detaljer.motta(
-                              resultat.alder,
-                              resultat.sum,
-                            ),
-                          )
-                        : t(
-                            tekster.detaljer.betale(
-                              resultat.alder,
-                              resultat.sum,
-                            ),
-                          )}
-                    </ListItem>
-                  ))}
-                </List>
-              </>
-            )}
+            <BodyLong spacing>{t(tekster.detaljer.utregningPerBarn)}</BodyLong>
+            <List>
+              {data.resultater.map((resultat, index) => (
+                <ListItem key={index}>
+                  {resultat.bidragstype === "MOTTAKER"
+                    ? t(tekster.detaljer.motta(resultat.alder, resultat.sum))
+                    : t(tekster.detaljer.betale(resultat.alder, resultat.sum))}
+                </ListItem>
+              ))}
+            </List>
           </ExpansionCardContent>
         </ExpansionCard>
 
@@ -279,7 +263,7 @@ const tekster = definerTekster({
     utregningPerBarn: {
       nb: "Barnebidraget over er en summering av hva du skal betale eller motta per måned for hvert av barna. Per barn ser beregningen slik ut:",
       en: "The child support above is a summary of what you should pay or receive per month for each of the children. For each child, the calculation looks like this:",
-      nn: "Det viktigaste grunnlaget for utrekninga er kva eit barn kostar, kjent som underhaldskostnadar. Desse summane er henta frå referansebudsjettet til SIFO, og dei blir oppdaterte kvart år. Kostnaden for borna dine er:",
+      nn: "Fostringstilskotet over er ei oppsummering av kva du skal betale eller motta per månad for kvart av barna. For kvart barn ser rekninga slik ut:",
     },
     motta: (alder, kostnad) => ({
       nb: (


### PR DESCRIPTION
Dette panelet var tomt i tilfeller med utregning for ett barn. Oppdaterer også nynorsk tekst om utregning

Slik ser det ut ved ett barn. Det tilfører ikke egentlig ny informasjon, men kan i hvert fall ikke være tom. Åpen for andre forslag til innhold. 

![image](https://github.com/user-attachments/assets/1560baf8-845f-4967-900b-bc4fb7b0a312)
