### PR TITLE
Bruke size på inputfelt for å unngå hjelpetekst over flere linjer

### DIFF
--- a/app/features/privatAvtale/Avtalepart.tsx
+++ b/app/features/privatAvtale/Avtalepart.tsx
@@ -1,6 +1,7 @@
 import { definerTekster, useOversettelse } from "~/utils/i18n";
 
 import { TextField } from "@navikt/ds-react";
+import { NAVN_TEXT_FIELD_HTML_SIZE } from "~/utils/ui";
 import { usePrivatAvtaleForm } from "./PrivatAvtaleFormProvider";
 import { sporPrivatAvtaleSpørsmålBesvart } from "./utils";
 
@@ -23,7 +24,7 @@ export const Avtalepart = ({ part }: Props) => {
         })}
         error={form.field(`${part}.fulltNavn`).error()}
         autoComplete="off"
-        htmlSize={30}
+        htmlSize={NAVN_TEXT_FIELD_HTML_SIZE}
       />
 
       <TextField

--- a/app/features/privatAvtale/PrivatAvtaleEnkeltbarn.tsx
+++ b/app/features/privatAvtale/PrivatAvtaleEnkeltbarn.tsx
@@ -2,6 +2,7 @@ import { PersonCrossIcon } from "@navikt/aksel-icons";
 import { Button, Radio, RadioGroup, TextField } from "@navikt/ds-react";
 import { useFormContext, useFormScope } from "@rvf/react";
 import { definerTekster, useOversettelse } from "~/utils/i18n";
+import { NAVN_TEXT_FIELD_HTML_SIZE } from "~/utils/ui";
 import { BidragstypeSchema } from "../skjema/beregning/schema";
 import { FormattertTallTextField } from "../skjema/FormattertTallTextField";
 import type { PrivatAvtaleSkjema } from "./skjemaSchema";
@@ -32,7 +33,7 @@ export const PrivatAvtaleEnkeltbarnSkjema = ({
           onBlur: sporPrivatAvtaleSpørsmålBesvart(t(tekster.fulltNavn.label)),
         })}
         error={barnField.field("fulltNavn").error()}
-        htmlSize={30}
+        htmlSize={NAVN_TEXT_FIELD_HTML_SIZE}
         autoComplete="off"
       />
 

--- a/app/features/skjema/manuell/EnkeltbarnSkjema.tsx
+++ b/app/features/skjema/manuell/EnkeltbarnSkjema.tsx
@@ -4,6 +4,7 @@ import { useFormContext, useFormScope } from "@rvf/react";
 import { useMemo } from "react";
 import { definerTekster, useOversettelse } from "~/utils/i18n";
 import { formatterSum } from "~/utils/tall";
+import { NAVN_TEXT_FIELD_HTML_SIZE } from "~/utils/ui";
 import { FormattertTallTextField } from "../FormattertTallTextField";
 import { usePersoninformasjon } from "../personinformasjon/usePersoninformasjon";
 import { Samvær } from "../Samvær";
@@ -54,7 +55,7 @@ export const EnkeltbarnSkjema = ({ barnIndex, onFjernBarn }: Props) => {
         description={t(tekster.navn.description)}
         error={barnField.field("navn").error()}
         autoComplete="off"
-        htmlSize={30}
+        htmlSize={NAVN_TEXT_FIELD_HTML_SIZE}
       />
       <TextField
         {...barnField.field("alder").getInputProps({

--- a/app/features/skjema/manuell/EnkeltbarnSkjema.tsx
+++ b/app/features/skjema/manuell/EnkeltbarnSkjema.tsx
@@ -53,7 +53,8 @@ export const EnkeltbarnSkjema = ({ barnIndex, onFjernBarn }: Props) => {
         })}
         description={t(tekster.navn.description)}
         error={barnField.field("navn").error()}
-        className="max-w-80"
+        autoComplete="off"
+        htmlSize={30}
       />
       <TextField
         {...barnField.field("alder").getInputProps({

--- a/app/features/skjema/manuell/MedforelderSkjema.tsx
+++ b/app/features/skjema/manuell/MedforelderSkjema.tsx
@@ -13,7 +13,8 @@ export function MedforelderSkjema() {
         error={form.field("medforelder.navn").error()}
         label={t(tekster.navn.label)}
         description={t(tekster.navn.description)}
-        className="max-w-80"
+        autoComplete="off"
+        htmlSize={30}
       />
     </div>
   );

--- a/app/features/skjema/manuell/MedforelderSkjema.tsx
+++ b/app/features/skjema/manuell/MedforelderSkjema.tsx
@@ -1,6 +1,7 @@
 import { TextField } from "@navikt/ds-react";
 import { useFormContext } from "@rvf/react";
 import { definerTekster, useOversettelse } from "~/utils/i18n";
+import { NAVN_TEXT_FIELD_HTML_SIZE } from "~/utils/ui";
 import type { ManueltSkjema } from "../schema";
 
 export function MedforelderSkjema() {
@@ -14,7 +15,7 @@ export function MedforelderSkjema() {
         label={t(tekster.navn.label)}
         description={t(tekster.navn.description)}
         autoComplete="off"
-        htmlSize={30}
+        htmlSize={NAVN_TEXT_FIELD_HTML_SIZE}
       />
     </div>
   );

--- a/app/utils/ui.ts
+++ b/app/utils/ui.ts
@@ -1,0 +1,1 @@
+export const NAVN_TEXT_FIELD_HTML_SIZE = 30;


### PR DESCRIPTION
Skru av autocomplete på navn på medforelder og barn