### PR TITLE
Legg til aria-live på slider verdibeskrivelse for bedre skjermleser-støtte

### DIFF
--- a/app/components/ui/slider.tsx
+++ b/app/components/ui/slider.tsx
@@ -36,6 +36,7 @@ function Slider({
   const id = eksternId ?? generertId;
   const labelId = `${id}-label`;
   const descriptionId = `${id}-description`;
+  const liveRegionId = `${id}-live-region`;
   const verdi = value
     ? [Number(value)]
     : defaultValue
@@ -107,9 +108,17 @@ function Slider({
           ))}
         </div>
       )}
+
       {valueDescription && (
-        <BodyShort className="font-bold mt-1">{valueDescription}</BodyShort>
+        <BodyShort
+          id={liveRegionId}
+          aria-live="polite"
+          className="font-bold mt-1"
+        >
+          {valueDescription}
+        </BodyShort>
       )}
+
       {error && <ErrorMessage aria-live="assertive">{error}</ErrorMessage>}
     </div>
   );


### PR DESCRIPTION
Skjermleseren fikk ikke beskjed om oppdateringer og leste derfor feil verdier når brukere endret slider-verdien raskt (f.eks. ved å trykke piltaster flere ganger).